### PR TITLE
Submit connection metrics to the AWS Backend

### DIFF
--- a/Config/default_aws_resource_mappings.json
+++ b/Config/default_aws_resource_mappings.json
@@ -1,0 +1,15 @@
+{
+    "AWSResourceMappings": {
+        "AWSMetrics.RESTApiStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Name/ID": "api"
+        },
+        "AWSMetrics.RESTApiId": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Name/ID": ""
+        }
+    },
+    "AccountId": "",
+    "Region": "us-east-1",
+    "Version": "1.1.0"
+}

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -29,12 +29,14 @@ ly_add_target(
             Gem::PhysX
             Gem::StartingPointInput
             Gem::DebugDraw
-        PRIVATE
+            Gem::AWSMetrics
+        PRIVATE       
             Gem::LmbrCentral.Static
             Gem::Multiplayer.Static
             Gem::PhysX.Static
             Gem::DebugDraw.Static
             Gem::ImGui.Static
+            Gem::AWSMetrics.Static
     AUTOGEN_RULES
         *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
         *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
@@ -138,7 +138,7 @@ namespace MultiplayerSample
 
         AZStd::vector<AWSMetrics::MetricsAttribute> clientConnectCountMetricsAttributes;
         clientConnectCountMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute(MetricsEventNameAttributeKey, ClientCountMetricsEvent));
-        clientConnectCountMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute(ClientCountMetricsEvent, (int) stats.m_clientConnectionCount));
+        clientConnectCountMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute(ClientCountMetricsEvent, aznumeric_cast<int>(stats.m_clientConnectionCount)));
 
         bool result = false;
         AWSMetrics::AWSMetricsRequestBus::BroadcastResult(result, &AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientConnectCountMetricsAttributes, 0, MetricsEventSource, false);
@@ -146,10 +146,6 @@ namespace MultiplayerSample
         {
             AZ_TracePrintf(AWSMetricsSubmissionComponentName.data(), "Failed to submit metrics: %s", ClientCountMetricsEvent.data());
         }
-    }
-
-    void AWSMetricsSubmissionComponent::OnSendMetricsSuccess([[maybe_unused]] int requestId)
-    {
     }
 
     void AWSMetricsSubmissionComponent::OnSendMetricsFailure([[maybe_unused]] int requestId, [[maybe_unused]] const AZStd::string& errorMessage)

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
@@ -30,7 +30,7 @@ namespace MultiplayerSample
 
             if (const auto editContext = serializationContext->GetEditContext())
             {
-                editContext->Class<AWSMetricsSubmissionComponent>(AWSMetricsSubmissionComponentName,
+                editContext->Class<AWSMetricsSubmissionComponent>(AWSMetricsSubmissionComponentName.data(),
                     "Handles metrics submission via the AWSMetrics Gem")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "MultiplayerSample")
@@ -93,7 +93,7 @@ namespace MultiplayerSample
                 AWSMetrics::AWSMetricsRequestBus::BroadcastResult(result, &AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientJointMetricsAttributes, 0, MetricsEventSource, true);
                 if (!result)
                 {
-                    AZ_TracePrintf(AWSMetricsSubmissionComponentName, "Failed to submit the %s metrics", ClientJoinMetricsEvent);
+                    AZ_TracePrintf(AWSMetricsSubmissionComponentName.data(), "Failed to submit metrics: %s", ClientJoinMetricsEvent.data());
                 }
             });
         AZ::Interface<IMultiplayer>::Get()->AddConnectionAcquiredHandler(m_connectHandler);
@@ -108,7 +108,7 @@ namespace MultiplayerSample
                 AWSMetrics::AWSMetricsRequestBus::BroadcastResult(result, &AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientLeaveMetricsAttributes, 0, MetricsEventSource, true);
                 if (!result)
                 {
-                    AZ_TracePrintf(AWSMetricsSubmissionComponentName, "Failed to submit the %s metrics", ClientLeaveMetricsEvent);
+                    AZ_TracePrintf(AWSMetricsSubmissionComponentName.data(), "Failed to submit metrics : % s", ClientLeaveMetricsEvent.data());
                 }
 
             });
@@ -144,7 +144,7 @@ namespace MultiplayerSample
         AWSMetrics::AWSMetricsRequestBus::BroadcastResult(result, &AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientConnectCountMetricsAttributes, 0, MetricsEventSource, false);
         if (!result)
         {
-            AZ_TracePrintf(AWSMetricsSubmissionComponentName, "Failed to submit the %s metrics", ClientCountMetricsEvent);
+            AZ_TracePrintf(AWSMetricsSubmissionComponentName.data(), "Failed to submit metrics: %s", ClientCountMetricsEvent.data());
         }
     }
 
@@ -154,6 +154,6 @@ namespace MultiplayerSample
 
     void AWSMetricsSubmissionComponent::OnSendMetricsFailure([[maybe_unused]] int requestId, [[maybe_unused]] const AZStd::string& errorMessage)
     {
-        AZ_TracePrintf(AWSMetricsSubmissionComponentName, "Failed to sent metrics: %s", errorMessage.c_str());
+        AZ_TracePrintf(AWSMetricsSubmissionComponentName.data(), "Failed to send metrics: %s", errorMessage.c_str());
     }
 }

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.cpp
@@ -1,0 +1,129 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#include "AWSMetricsSubmissionComponent.h"
+
+#include <Multiplayer/IMultiplayer.h>
+#include <AWSMetricsBus.h>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace MultiplayerSample
+{
+    using namespace Multiplayer;
+
+    AZ_CVAR(bool, sv_submit_aws_metrics, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Whether to submit metrics to the AWS backend");
+
+    void AWSMetricsSubmissionComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (const auto serializationContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializationContext->Class<AWSMetricsSubmissionComponent, Component>()
+                ->Field("AWS Metrics Submission Interval Hint in Seconds", &AWSMetricsSubmissionComponent::m_AWSMetricsSubmissionIntervalInSecHint)
+                ->Version(1);
+
+            if (const auto editContext = serializationContext->GetEditContext())
+            {
+                editContext->Class<AWSMetricsSubmissionComponent>("AWSMetricsSubmissionComponent",
+                    "Handles metrics submission via the AWSMetrics Gem")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "MultiplayerSample")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(nullptr, &AWSMetricsSubmissionComponent::m_AWSMetricsSubmissionIntervalInSecHint, "AWS Metrics Submission Interval Hint in Seconds",
+                        "Hint for the AWS metrics submission interval. "
+                        "This interval will apply to the metrics that need to be submitted regulary like player connection count.")
+                    ;
+            }
+        }
+    }
+
+    void AWSMetricsSubmissionComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("AWSMetricsSubmissionComponent"));
+    }
+
+    void AWSMetricsSubmissionComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("AWSMetricsSubmissionComponent"));
+    }
+
+    void AWSMetricsSubmissionComponent::Activate()
+    {
+        if (!sv_submit_aws_metrics)
+        {
+            return;
+        }
+
+        RegisterPlayerConnectionMetrics();
+
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void AWSMetricsSubmissionComponent::Deactivate()
+    {
+        if (!sv_submit_aws_metrics)
+        {
+            return;
+        }
+
+        AZ::TickBus::Handler::BusDisconnect();
+
+        AWSMetrics::AWSMetricsRequestBus::Broadcast(&AWSMetrics::AWSMetricsRequests::FlushMetrics);
+    }
+
+    void AWSMetricsSubmissionComponent::RegisterPlayerConnectionMetrics()
+    {
+        // Add a handler for the ConnectionAcquired event to submit the client_join metrics
+        m_connectHandler = ConnectionAcquiredEvent::Handler([](MultiplayerAgentDatum)
+            {
+                AZStd::vector<AWSMetrics::MetricsAttribute> clientJointMetricsAttributes;
+                clientJointMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute("event_name", "client_join"));
+
+                AWSMetrics::AWSMetricsRequestBus::Broadcast(&AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientJointMetricsAttributes, 0, AZStd::string("MultiplayerSample"), true);
+            });
+        AZ::Interface<IMultiplayer>::Get()->AddConnectionAcquiredHandler(m_connectHandler);
+
+        // Add a handler for the EndpointDisonnected event to submit the client_leave metrics
+        m_disconnectHandler = EndpointDisonnectedEvent::Handler([](MultiplayerAgentType)
+            {
+                AZStd::vector<AWSMetrics::MetricsAttribute> clientLeaveMetricsAttributes;
+                clientLeaveMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute("event_name", "client_leave"));
+
+                AWSMetrics::AWSMetricsRequestBus::Broadcast(&AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientLeaveMetricsAttributes, 0, AZStd::string("MultiplayerSample"), true);
+            });
+        AZ::Interface<IMultiplayer>::Get()->AddEndpointDisonnectedHandler(m_disconnectHandler);
+    }
+
+    void AWSMetricsSubmissionComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (!AZ::Interface<IMultiplayer>::Get() ||
+            AZ::Interface<IMultiplayer>::Get()->GetAgentType() != MultiplayerAgentType::DedicatedServer)
+        {
+            return;
+        }
+
+        m_interval += deltaTime;
+        if (m_interval > m_AWSMetricsSubmissionIntervalInSecHint)
+        {
+            // Submit the connection count metrics periodically to the AWS backend
+            SubmitEndpointConnectionCountMetrics();
+            m_interval = 0;
+        }
+    }
+
+    void AWSMetricsSubmissionComponent::SubmitEndpointConnectionCountMetrics()
+    {
+        MultiplayerStats& stats = AZ::Interface<IMultiplayer>::Get()->GetStats();
+
+        AZStd::vector<AWSMetrics::MetricsAttribute> clientConnectCountMetricsAttributes;
+        clientConnectCountMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute("event_name", "client_connection_count"));
+        clientConnectCountMetricsAttributes.emplace_back(AWSMetrics::MetricsAttribute("client_connection_count", (int) stats.m_clientConnectionCount));
+        AWSMetrics::AWSMetricsRequestBus::Broadcast(&AWSMetrics::AWSMetricsRequests::SubmitMetrics, clientConnectCountMetricsAttributes, 0, AZStd::string("MultiplayerSample"), true);
+    }
+}

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
@@ -47,7 +47,6 @@ namespace MultiplayerSample
 
         ////////////////////////////////////////////////////////////////////////
         // AWSMetricsNotificationBus implementation
-        void OnSendMetricsSuccess(int requestId) override;
         void OnSendMetricsFailure(int requestId, const AZStd::string& errorMessage) override;
 
     private:

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
@@ -16,12 +16,12 @@ using namespace Multiplayer;
 
 namespace MultiplayerSample
 {
-    static constexpr char AWSMetricsSubmissionComponentName[] = "AWSMetricsSubmissionComponent";
-    static constexpr char ClientJoinMetricsEvent[] = "client_join";
-    static constexpr char ClientLeaveMetricsEvent[] = "client_leave";
-    static constexpr char ClientCountMetricsEvent[] = "client_connection_count";
-    static constexpr char MetricsEventNameAttributeKey[] = "event_name";
-    static constexpr char MetricsEventSource[] = "MultiplayerSample";
+    static constexpr AZStd::string_view AWSMetricsSubmissionComponentName = "AWSMetricsSubmissionComponent";
+    static constexpr AZStd::string_view ClientJoinMetricsEvent = "client_join";
+    static constexpr AZStd::string_view ClientLeaveMetricsEvent = "client_leave";
+    static constexpr AZStd::string_view ClientCountMetricsEvent = "client_connection_count";
+    static constexpr AZStd::string_view MetricsEventNameAttributeKey = "event_name";
+    static constexpr AZStd::string_view MetricsEventSource = "MultiplayerSample";
 
     //! Component for submitting metrics to the AWS backend
     class AWSMetricsSubmissionComponent
@@ -63,6 +63,6 @@ namespace MultiplayerSample
         //! This value only applies to metrics which are required to be submitted periodically, like client connection counts.
         float m_AWSMetricsSubmissionIntervalInSec=60.0;
 
-        float m_interval = 0;
+        float m_interval = 0.0;
     };
 }

--- a/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
+++ b/Gem/Code/Source/Components/AWSMetricsSubmissionComponent.h
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+
+using namespace Multiplayer;
+
+namespace MultiplayerSample
+{
+    //! Component for submitting metrics to the AWS backend
+    class AWSMetricsSubmissionComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(AWSMetricsSubmissionComponent, "{F16A5A09-C351-4862-8CCA-3E8419123538}", Component);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+
+        void Activate() override;
+        void Deactivate() override;
+
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+    private:
+        //! Connect handlers to the player connection events for submitting client_join and client_leave metrics
+        void RegisterPlayerConnectionMetrics();
+        //! Submit the client_connection_count metrics
+        void SubmitEndpointConnectionCountMetrics();
+
+        ConnectionAcquiredEvent::Handler m_connectHandler;
+        EndpointDisonnectedEvent::Handler m_disconnectHandler;
+
+        //! Time interval for submitting metrics regularly.
+        //! Default to 1 minute to reduce AWS costs and it's configurable via the Editor.
+        float m_AWSMetricsSubmissionIntervalInSecHint=60.0;
+
+        float m_interval = 0;
+    };
+}

--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -11,6 +11,7 @@
 #include <Components/PerfTest/NetworkPrefabSpawnerComponent.h>
 #include <Components/PerfTest/NetworkRandomImpulseComponent.h>
 #include <Components/PerfTest/NetworkTestSpawnerComponent.h>
+#include <Components/AWSMetricsSubmissionComponent.h>
 #include <Source/AutoGen/AutoComponentTypes.h>
 
 #include "MultiplayerSampleSystemComponent.h"
@@ -32,6 +33,7 @@ namespace MultiplayerSample
                 MultiplayerSampleSystemComponent::CreateDescriptor(),
                 ExampleFilteredEntityComponent::CreateDescriptor(),
                 NetworkPrefabSpawnerComponent::CreateDescriptor(),
+                AWSMetricsSubmissionComponent::CreateDescriptor()
             });
 
             CreateComponentDescriptors(m_descriptors);

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -44,6 +44,8 @@ set(FILES
     Source/Components/NetworkStressTestComponent.h
     Source/Components/NetworkPlayerMovementComponent.cpp
     Source/Components/NetworkPlayerMovementComponent.h
+    Source/Components/AWSMetricsSubmissionComponent.cpp
+    Source/Components/AWSMetricsSubmissionComponent.h
     Source/Spawners/IPlayerSpawner.h
     Source/Spawners/RoundRobinSpawner.h
     Source/Spawners/RoundRobinSpawner.cpp

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -27,6 +27,11 @@
                 "$type": "EditorPendingCompositionComponent",
                 "Id": 13533444088377782884
             },
+            "Component_[1391568711779136097]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 1391568711779136097,
+                "LocalBookmarkFileName": "SampleBase_308035330350.setreg"
+            },
             "Component_[14619812868403384733]": {
                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                 "Id": 14619812868403384733,
@@ -38,11 +43,6 @@
                 "m_template": {
                     "$type": "MultiplayerSample::ExampleFilteredEntityComponent"
                 }
-            },
-            "Component_[2030071479686411024]": {
-                "$type": "LocalViewBookmarkComponent",
-                "Id": 2030071479686411024,
-                "LocalBookmarkFileName": "SampleBase_109645868073.setreg"
             },
             "Component_[3902259769182016681]": {
                 "$type": "EditorLockComponent",
@@ -82,16 +82,16 @@
             "Id": "Entity_[14030996048227]",
             "Name": "StressTestEntity",
             "Components": {
-                "Component_[11071255408563586395]": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 11071255408563586395
-                },
-                "Component_[12666222616595027521]": {
+                "Component_[10336352974327950274]": {
                     "$type": "GenericComponentWrapper",
-                    "Id": 12666222616595027521,
+                    "Id": 10336352974327950274,
                     "m_template": {
                         "$type": "AWSMetricsSubmissionComponent"
                     }
+                },
+                "Component_[11071255408563586395]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11071255408563586395
                 },
                 "Component_[1271454470034210481]": {
                     "$type": "SelectionComponent",

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -39,6 +39,11 @@
                     "$type": "MultiplayerSample::ExampleFilteredEntityComponent"
                 }
             },
+            "Component_[2030071479686411024]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 2030071479686411024,
+                "LocalBookmarkFileName": "SampleBase_109645868073.setreg"
+            },
             "Component_[3902259769182016681]": {
                 "$type": "EditorLockComponent",
                 "Id": 3902259769182016681
@@ -80,6 +85,13 @@
                 "Component_[11071255408563586395]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 11071255408563586395
+                },
+                "Component_[12666222616595027521]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12666222616595027521,
+                    "m_template": {
+                        "$type": "AWSMetricsSubmissionComponent"
+                    }
                 },
                 "Component_[1271454470034210481]": {
                     "$type": "SelectionComponent",
@@ -286,6 +298,13 @@
                             0.0,
                             -0.5
                         ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/Registry/awsMetricsClientConfiguration.setreg
+++ b/Registry/awsMetricsClientConfiguration.setreg
@@ -1,0 +1,14 @@
+{
+    "Amazon": 
+    {
+        "Gems": 
+        {
+            "AWSMetrics": {
+                "OfflineRecording": false,
+                "MaxQueueSizeInMb": 0.3,
+                "QueueFlushPeriodInSeconds": 60,
+                "MaxNumRetries":  1
+            }
+        }
+    }
+}

--- a/Registry/awscoreconfiguration.setreg
+++ b/Registry/awscoreconfiguration.setreg
@@ -1,0 +1,10 @@
+{
+    "Amazon": 
+    {
+        "AWSCore": 
+        {
+            "ProfileName": "default",
+            "ResourceMappingConfigFileName": "default_aws_resource_mappings.json"
+        }
+    } 
+}


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>
Add a new component for collecting and submitting server metrics to the AWS backend.
Update the sample level and add the new component to the StressTestEntity.
Verified that Metrics can be sent to the AWS Backend (require to customize the AWSMetrics Gem sample CDK application for visualizing the server metrics)

![image](https://user-images.githubusercontent.com/68558268/176509374-c992eafa-cab0-4037-8e4d-28da01a9f914.png)
