### PR TITLE
Add networking to teleport component

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
@@ -12,7 +12,7 @@
                        Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
 
     <RemoteProcedure
-        Name="SendTeleportLocation" 
+        Name="Teleport" 
         InvokeFrom="Server" 
         HandleOn="Authority" 
         IsPublic="true" 

--- a/Gem/Code/Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<Component
+    Name="NetworkTeleportCompatibleComponent"
+    Namespace="MultiplayerSample"
+    OverrideComponent="true" 
+    OverrideController="true" 
+    OverrideInclude="Source/Components/NetworkTeleportCompatibleComponent.h"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" 
+                       Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+
+    <RemoteProcedure
+        Name="SendTeleportLocation" 
+        InvokeFrom="Server" 
+        HandleOn="Authority" 
+        IsPublic="true" 
+        IsReliable="true" 
+        GenerateEventBindings="true"
+        Description="Teleport occured RPC">
+        <Param Type="AZ::Vector3" Name="TeleportedLocation"/>
+    </RemoteProcedure>
+</Component>

--- a/Gem/Code/Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<Component
+    Name="NetworkTeleportComponent"
+    Namespace="MultiplayerSample"
+    OverrideComponent="true"
+    OverrideController="true"
+    OverrideInclude="Source/Components/NetworkTeleportComponent.h"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <ArchetypeProperty 
+        Type="AZ::EntityId" Name="Destination" Init="" ExposeToEditor="true"/>
+</Component>

--- a/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
@@ -18,14 +18,6 @@ namespace MultiplayerSample
         NetworkTeleportCompatibleComponentBase::Reflect(context);
     }
 
-    void NetworkTeleportCompatibleComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-    }
-
-    void NetworkTeleportCompatibleComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-    }
-
     // Controller
 
     NetworkTeleportCompatibleComponentController::NetworkTeleportCompatibleComponentController(NetworkTeleportCompatibleComponent& parent)
@@ -33,17 +25,7 @@ namespace MultiplayerSample
     {
     }
 
-    void NetworkTeleportCompatibleComponentController::OnActivate(
-        [[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-    }
-
-    void NetworkTeleportCompatibleComponentController::OnDeactivate(
-        [[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-    }
-
-    void  NetworkTeleportCompatibleComponentController::HandleSendTeleportLocation(
+    void  NetworkTeleportCompatibleComponentController::HandleTeleport(
         [[maybe_unused]] AzNetworking::IConnection* invokingConnection, [[maybe_unused]] const AZ::Vector3& teleportedLocation)
     {
         AZ::Entity* self = GetEntity();

--- a/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
@@ -1,0 +1,73 @@
+#include <Source/Components/NetworkTeleportCompatibleComponent.h>
+
+#include <Multiplayer/Components/NetworkTransformComponent.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
+
+namespace MultiplayerSample
+{
+    void NetworkTeleportCompatibleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<NetworkTeleportCompatibleComponent, NetworkTeleportCompatibleComponentBase>()
+                ->Version(1);
+        }
+        NetworkTeleportCompatibleComponentBase::Reflect(context);
+    }
+
+    void NetworkTeleportCompatibleComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void NetworkTeleportCompatibleComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    // Controller
+
+    NetworkTeleportCompatibleComponentController::NetworkTeleportCompatibleComponentController(NetworkTeleportCompatibleComponent& parent)
+        : NetworkTeleportCompatibleComponentControllerBase(parent)
+    {
+    }
+
+    void NetworkTeleportCompatibleComponentController::OnActivate(
+        [[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void NetworkTeleportCompatibleComponentController::OnDeactivate(
+        [[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void  NetworkTeleportCompatibleComponentController::HandleSendTeleportLocation(
+        [[maybe_unused]] AzNetworking::IConnection* invokingConnection, [[maybe_unused]] const AZ::Vector3& teleportedLocation)
+    {
+        AZ::Entity* self = GetEntity();
+        
+        AZ_TracePrintf("TeleportCompatibleComponent", "Teleporting entity %s to (%f,%f)\n", 
+            self->GetName().c_str(),
+            teleportedLocation.GetX(), 
+            teleportedLocation.GetY());
+
+        AZ::EntityId selfId = self->GetId();
+        
+        // disable physics (needed to move rigid bodies)
+        // see: https://github.com/o3de/o3de/issues/2541
+        Physics::RigidBodyRequestBus::Event(selfId, &Physics::RigidBodyRequestBus::Events::DisablePhysics);
+
+        // move self and increment resetCount to prevent transform interpolation
+        AZ::TransformBus::Event(selfId,
+            &AZ::TransformBus::Events::SetWorldTranslation, teleportedLocation);
+
+        Multiplayer::NetworkTransformComponentController* netTransform = GetNetworkTransformComponentController();
+        netTransform->SetResetCount(netTransform->GetResetCount() + 1);
+
+        // re-enable physics
+        Physics::RigidBodyRequestBus::Event(selfId, &Physics::RigidBodyRequestBus::Events::EnablePhysics);
+    }
+
+} // namespace MultiplayerSample

--- a/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.h
+++ b/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.h>
+
+namespace MultiplayerSample
+{
+    class NetworkTeleportCompatibleComponent
+        : public NetworkTeleportCompatibleComponentBase
+    {
+    public:
+        AZ_MULTIPLAYER_COMPONENT(
+            MultiplayerSample::NetworkTeleportCompatibleComponent, s_networkTeleportCompatibleComponentConcreteUuid, MultiplayerSample::NetworkTeleportCompatibleComponentBase);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void OnInit() override {}
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+    };
+
+    class NetworkTeleportCompatibleComponentController
+        : public NetworkTeleportCompatibleComponentControllerBase
+    {
+    public:
+        NetworkTeleportCompatibleComponentController(NetworkTeleportCompatibleComponent& parent);
+
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+        void HandleSendTeleportLocation(
+            AzNetworking::IConnection* invokingConnection, const AZ::Vector3& teleportedLocation) override;
+    };
+
+} // namespace MultiplayerSample

--- a/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.h
+++ b/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.h
@@ -14,8 +14,8 @@ namespace MultiplayerSample
         static void Reflect(AZ::ReflectContext* context);
 
         void OnInit() override {}
-        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
-        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
+        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
     };
 
     class NetworkTeleportCompatibleComponentController
@@ -24,10 +24,10 @@ namespace MultiplayerSample
     public:
         NetworkTeleportCompatibleComponentController(NetworkTeleportCompatibleComponent& parent);
 
-        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
-        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
+        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
 
-        void HandleSendTeleportLocation(
+        void HandleTeleport(
             AzNetworking::IConnection* invokingConnection, const AZ::Vector3& teleportedLocation) override;
     };
 

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
@@ -6,8 +6,9 @@
  */
 
 #include "NetworkTeleportComponent.h"
-#include <Multiplayer/Components/NetworkTransformComponent.h>
 
+#include <Multiplayer/Components/NetworkTransformComponent.h>
+#include <Source/Components/NetworkTeleportCompatibleComponent.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
@@ -23,29 +24,27 @@ namespace MultiplayerSample
     {
         if (auto serializationContext = azrtti_cast<AZ::SerializeContext*>(reflection))
         {
-            serializationContext->Class<NetworkTeleportComponent, Component>()
-                ->Field("Destination", &NetworkTeleportComponent::m_reset)
-                ->Version(3);
-
-            if (AZ::EditContext* editContext = serializationContext->GetEditContext())
-            {
-                editContext->Class<NetworkTeleportComponent>("Network Teleport Component",
-                    "Teleports colliding player entities to a fixed location")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, 
-                        "MultiplayerSample")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, 
-                        AZ_CRC_CE("Game"))
-                    ->DataElement(0, &NetworkTeleportComponent::m_reset,
-                        "Destination", "Entity at which to teleport the colliding player")
-                    ;
-            }
+            serializationContext->Class<NetworkTeleportComponent, NetworkTeleportComponentBase>()
+                ->Version(4);
+            NetworkTeleportComponentBase::Reflect(reflection);
         }
     }
 
-    NetworkTeleportComponent::NetworkTeleportComponent()
-        : m_enterTrigger([this](
-            AzPhysics::SimulatedBodyHandle bodyHandle, 
+    void NetworkTeleportComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        AZ_TracePrintf("Teleporter", "Client is activating...\n");
+    }
+
+    void NetworkTeleportComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    // Controller
+
+    NetworkTeleportComponentController::NetworkTeleportComponentController(NetworkTeleportComponent& parent)
+        : NetworkTeleportComponentControllerBase(parent)
+        , m_enterTrigger([this](
+            AzPhysics::SimulatedBodyHandle bodyHandle,
             const AzPhysics::TriggerEvent& triggerEvent)
             {
                 this->OnTriggerEnter(bodyHandle, triggerEvent);
@@ -53,90 +52,81 @@ namespace MultiplayerSample
     {
     }
 
-    void NetworkTeleportComponent::Activate()
+    void NetworkTeleportComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        AZ_TracePrintf("Teleporter", "Controller is activating...\n");
         auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-         if (physicsSystem)
+        const AZ::EntityId self = GetEntity()->GetId();
+        if (physicsSystem)
         {
-            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(GetEntityId());
+            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(self);
             AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
                 sceneHandle, bodyHandle, m_enterTrigger);
         }
     }
 
-    void NetworkTeleportComponent::OnTriggerEnter(
+    void NetworkTeleportComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void NetworkTeleportComponentController::OnTriggerEnter(
         [[maybe_unused]] AzPhysics::SimulatedBodyHandle bodyHandle, const AzPhysics::TriggerEvent& triggerEvent)
     {
-
         if (triggerEvent.m_otherBody)
         {
-            // TODO: validate it's a player entity
-            AZ::Vector3 teleportLocation = GetDestination();
-            AZ_TracePrintf("Teleporter", "Destination point X is: %f\n",
-                teleportLocation.GetX());
+            AZ::Vector3 teleportLocation = GetDestinationVector();
+            AZ_TracePrintf("Teleporter", "Destination point X, Y is: %f, %f\n",
+                teleportLocation.GetX(), teleportLocation.GetY());
 
             AZ::Entity* otherEntity = GetCollidingEntity(triggerEvent.m_otherBody);
             TeleportPlayer(teleportLocation, otherEntity);
         }
     }
 
-    AZ::Entity* NetworkTeleportComponent::GetCollidingEntity(AzPhysics::SimulatedBody* collidingBody) const
+    AZ::Entity* NetworkTeleportComponentController::GetCollidingEntity(
+        AzPhysics::SimulatedBody* collidingBody) const
     {
-        AZ::Entity* collidingEntity = nullptr;		
+        AZ::Entity* collidingEntity = nullptr;
         if (collidingBody)
         {
             AZ::EntityId collidingEntityId = collidingBody->GetEntityId();
             AZ::ComponentApplicationBus::BroadcastResult(
                 collidingEntity, &AZ::ComponentApplicationBus::Events::FindEntity, collidingEntityId);
         }
+
         return collidingEntity;
     }
 
-    AZ::Vector3 NetworkTeleportComponent::GetDestination() const
+    AZ::Vector3 NetworkTeleportComponentController::GetDestinationVector() const
     {
-        AZ::Vector3 newLocation = AZ::Vector3::CreateZero();
-        AZ::TransformBus::EventResult(newLocation, m_reset,
+        AZ::Vector3 location = GetEntity()->GetTransform()->
+            GetWorldTM().GetTranslation();
+
+        AZ::EntityId destination = GetDestination();
+
+        AZ::TransformBus::EventResult(location, destination,
             &AZ::TransformBus::Events::GetWorldTranslation);
 
-        return newLocation;
+        return location;
     }
 
-    void NetworkTeleportComponent::TeleportPlayer(
-        const AZ::Vector3& v, AZ::Entity* entity)
+    void NetworkTeleportComponentController::TeleportPlayer(
+        const AZ::Vector3& vector, AZ::Entity* entity)
     {
         if (entity)
         {
-            AZ::EntityId playerToTeleport = entity->GetId();
-
-            AZ_TracePrintf(
-                "Teleporter", "Attempting to teleport entity: %s\n", entity->GetName().c_str());
-
-            // disable physics so we can move entity
-            Physics::RigidBodyRequestBus::Event(playerToTeleport,
-                &Physics::RigidBodyRequestBus::Events::DisablePhysics);
-
-            // move the entity
-            AZ::TransformBus::Event(playerToTeleport,
-                &AZ::TransformBus::Events::SetWorldTranslation, v);
-
-            // increment resetCount so it doesn't try to interplate from last location
-            Multiplayer::NetworkTransformComponent* netTransform =
-                entity->FindComponent<Multiplayer::NetworkTransformComponent>();
-
-            if (netTransform && netTransform->GetController()) 
+            MultiplayerSample::NetworkTeleportCompatibleComponent* teleportable =
+                entity->FindComponent<MultiplayerSample::NetworkTeleportCompatibleComponent>();
+            if (teleportable)
             {
-                auto controller = 
-                    static_cast<Multiplayer::NetworkTransformComponentController*>(netTransform->GetController());
-
-                AZ_TracePrintf(
-                    "Teleporter", "updating resetCount to : %u\n", (controller->GetResetCount() + 1));
-
-                controller->SetResetCount(controller->GetResetCount() + 1);
+                teleportable->SendTeleportLocation(vector);
             }
-
-            // re-enable physics
-            Physics::RigidBodyRequestBus::Event(playerToTeleport,
-                &Physics::RigidBodyRequestBus::Events::EnablePhysics);
+            else
+            {
+                AZ_TracePrintf("Teleporter", "colliding entity %s is not teleport compatible! NoOp.\n", 
+                    entity->GetName().c_str());
+            }
         }
     }
-}
+
+} // namespace MultiplayerSample

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
@@ -30,15 +30,6 @@ namespace MultiplayerSample
         }
     }
 
-    void NetworkTeleportComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-        AZ_TracePrintf("Teleporter", "Client is activating...\n");
-    }
-
-    void NetworkTeleportComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-    }
-
     // Controller
 
     NetworkTeleportComponentController::NetworkTeleportComponentController(NetworkTeleportComponent& parent)
@@ -54,19 +45,14 @@ namespace MultiplayerSample
 
     void NetworkTeleportComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        AZ_TracePrintf("Teleporter", "Controller is activating...\n");
         auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        const AZ::EntityId self = GetEntity()->GetId();
         if (physicsSystem)
         {
-            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(self);
+            const AZ::EntityId selfId = GetEntity()->GetId();
+            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(selfId);
             AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
                 sceneHandle, bodyHandle, m_enterTrigger);
         }
-    }
-
-    void NetworkTeleportComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
     }
 
     void NetworkTeleportComponentController::OnTriggerEnter(
@@ -119,7 +105,7 @@ namespace MultiplayerSample
                 entity->FindComponent<MultiplayerSample::NetworkTeleportCompatibleComponent>();
             if (teleportable)
             {
-                teleportable->SendTeleportLocation(vector);
+                teleportable->Teleport(vector);
             }
             else
             {

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.h
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.h
@@ -27,8 +27,8 @@ namespace MultiplayerSample
         static void Reflect(AZ::ReflectContext* reflection);
 
         void OnInit() override {};
-        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
-        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
+        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
     };
 
     class NetworkTeleportComponentController
@@ -38,7 +38,7 @@ namespace MultiplayerSample
         NetworkTeleportComponentController(NetworkTeleportComponent& parent);
 
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
-        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
 
     private:
         AzPhysics::SimulatedBodyEvents::OnTriggerEnter::Handler m_enterTrigger;

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.h
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AzCore/Component/Component.h>
+#include <Source/AutoGen/NetworkTeleportComponent.AutoComponent.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
 
@@ -18,28 +18,36 @@ namespace MultiplayerSample
      * 
      */
     class NetworkTeleportComponent
-        : public AZ::Component
+        : public NetworkTeleportComponentBase
     {
     public:
-        AZ_COMPONENT(NetworkTeleportComponent,
-            "{917a6318-e047-4ec5-b6ed-bc95f74bd287}");
+        AZ_COMPONENT(NetworkTeleportComponent, "{917a6318-e047-4ec5-b6ed-bc95f74bd287}", 
+            NetworkTeleportComponentBase);
 
         static void Reflect(AZ::ReflectContext* reflection);
 
-        NetworkTeleportComponent();
+        void OnInit() override {};
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+    };
 
-        void Activate() override;
-        void Deactivate() override {};
+    class NetworkTeleportComponentController
+        : public NetworkTeleportComponentControllerBase
+    {
+    public:
+        NetworkTeleportComponentController(NetworkTeleportComponent& parent);
+
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     private:
         AzPhysics::SimulatedBodyEvents::OnTriggerEnter::Handler m_enterTrigger;
         void OnTriggerEnter(
             AzPhysics::SimulatedBodyHandle bodyHandle, const AzPhysics::TriggerEvent& triggerEvent);
 
-        AZ::EntityId m_reset;
-
         AZ::Entity* GetCollidingEntity(AzPhysics::SimulatedBody* collidingBody) const;
-        AZ::Vector3 GetDestination() const;
+        AZ::Vector3 GetDestinationVector() const;
         void TeleportPlayer(const AZ::Vector3& vector, AZ::Entity* entity);
     };
-}
+
+} // namespace MultiplayerSample

--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -34,8 +34,7 @@ namespace MultiplayerSample
                 MultiplayerSampleSystemComponent::CreateDescriptor(),
                 ExampleFilteredEntityComponent::CreateDescriptor(),
                 NetworkPrefabSpawnerComponent::CreateDescriptor(),
-                UiCanvasDemoPlacardComponent::CreateDescriptor(),
-                NetworkTeleportComponent::CreateDescriptor()
+                UiCanvasDemoPlacardComponent::CreateDescriptor()
             });
 
             CreateComponentDescriptors(m_descriptors);

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -19,6 +19,8 @@ set(FILES
     Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
+    Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
+    Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
     Source/Components/ExampleFilteredEntityComponent.h
     Source/Components/ExampleFilteredEntityComponent.cpp
     Source/Components/NetworkAiComponent.cpp
@@ -33,6 +35,8 @@ set(FILES
     Source/Components/NetworkRandomComponent.h
     Source/Components/NetworkTeleportComponent.cpp
     Source/Components/NetworkTeleportComponent.h
+    Source/Components/NetworkTeleportCompatibleComponent.cpp 
+    Source/Components/NetworkTeleportCompatibleComponent.h
     Source/Components/NetworkWeaponsComponent.cpp
     Source/Components/NetworkWeaponsComponent.h
     Source/Components/NetworkSimplePlayerCameraComponent.cpp


### PR DESCRIPTION
This change adds multiplayer component xml and autogen changes to the existing (but hithero misleadingly named) `NetworkTeleportComponent`. It also:
* moves collision detection and transform changes to controllers so they're server authoritative
* adds a new `NetworkTeleportCompatibleComponent` with a Server-to-Authority RPC which, when attached to a teleport-able entity, performs the actual transform changes. 
  * If/when an equivalent RPC is added to a more generic component (such as `NetworkTransformComponent`), `NetworkTeleportComponent` can migrate to that and this component can be deleted.

### Testing

Similar to those in https://github.com/aws-lumberyard-dev/o3de-multiplayersample/pull/9 but:
1. add a "Network Binding" and "Network Transform" to the "Portal" component
2. bundle the "Portal" component and its respawn location (separate entity) into the same prefab.
3. add a "Network Teleport Compatible" component to the player prefab (steps for how to do this available [here](https://www.o3de.org/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/#add-a-remote-procedure-call))
4. after hitting `ctrl + G` when testing in editor, most debug logs will now be emitted from the "EditorServer":

![image](https://user-images.githubusercontent.com/34254888/180898000-37118cec-5f6d-4f42-b3a8-5c9d21505827.png)
