### PR TITLE
Improved Network Match component

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -8,14 +8,12 @@
 	OverrideInclude="Source/Components/NetworkMatchComponent.h"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-    <!-- 
-	Round time is in seconds and is using an integer type to improve network traffic, even a signed int16 gives us 9 hours 
-	for a round duration. A float type would result in sending 4 bytes on every tick, where as here we are sending 2 bytes 
-	once a second. 
-	-->
-    <NetworkProperty Type="int16_t" Name="RoundTime" Init="120" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The remaining time in the round in seconds" />
+    <Include File="MultiplayerSampleTypes.h"/>
+
+	<!-- Round time is in seconds and is quantized to 2 bytes to reduce network traffic	-->
+    <NetworkProperty Type="RoundTimeSec" Name="RoundTime" Init="RoundTimeSec{120}" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The remaining time in the round in seconds" />
     <NetworkProperty Type="uint16_t" Name="RoundNumber" Init="1" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The current round number" />
 
-    <ArchetypeProperty Type="int16_t"  Name="RoundDuration"  Init="120" ExposeToEditor="true" Description="Total time of a round in seconds" />
+    <ArchetypeProperty Type="float"  Name="RoundDuration"  Init="120.f" ExposeToEditor="true" Description="Total time of a round in seconds" />
     <ArchetypeProperty Type="uint16_t"  Name="TotalRounds"  Init="3" ExposeToEditor="true" Description="Total number of rounds" />
 </Component>

--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -8,9 +8,14 @@
 	OverrideInclude="Source/Components/NetworkMatchComponent.h"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-    <NetworkProperty Type="float" Name="RoundTime" Init="120.0f" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The remaining time in the round" />
+    <!-- 
+	Round time is in seconds and is using an integer type to improve network traffic, even a signed int16 gives us 9 hours 
+	for a round duration. A float type would result in sending 4 bytes on every tick, where as here we are sending 2 bytes 
+	once a second. 
+	-->
+    <NetworkProperty Type="int16_t" Name="RoundTime" Init="120" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The remaining time in the round in seconds" />
     <NetworkProperty Type="uint16_t" Name="RoundNumber" Init="1" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The current round number" />
 
-    <ArchetypeProperty Type="float"  Name="RoundDuration"  Init="120.0f" ExposeToEditor="true" Description="Total time of a round" />
+    <ArchetypeProperty Type="int16_t"  Name="RoundDuration"  Init="120" ExposeToEditor="true" Description="Total time of a round in seconds" />
     <ArchetypeProperty Type="uint16_t"  Name="TotalRounds"  Init="3" ExposeToEditor="true" Description="Total number of rounds" />
 </Component>

--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -10,7 +10,7 @@
 
     <Include File="MultiplayerSampleTypes.h"/>
 
-	<!-- Round time is in seconds and is quantized to 2 bytes to reduce network traffic	-->
+    <!-- Round time is in seconds and is quantized to 2 bytes to reduce network traffic	-->
     <NetworkProperty Type="RoundTimeSec" Name="RoundTime" Init="RoundTimeSec{120}" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The remaining time in the round in seconds" />
     <NetworkProperty Type="uint16_t" Name="RoundNumber" Init="1" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="true" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="The current round number" />
 

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -18,18 +18,20 @@ namespace MultiplayerSample
     {
         SetRoundTime(GetRoundDuration());
         SetRoundNumber(1);
-        AZ::TickBus::Handler::BusConnect();
+
+        // Tick once a second, this way we can keep the time as an 2 byte integer instead of a float.
+        m_roundTickEvent.Enqueue(AZ::TimeMs{ 1000 }, true);
     }
 
     void NetworkMatchComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        AZ::TickBus::Handler::BusDisconnect();
+        m_roundTickEvent.RemoveFromQueue();
     }
 
     void NetworkMatchComponentController::EndMatch()
     {
         //Signal event to end the match
-        ;
+        m_roundTickEvent.RemoveFromQueue();
     }
 
     void NetworkMatchComponentController::EndRound()
@@ -48,18 +50,13 @@ namespace MultiplayerSample
         }
     }
 
-    void NetworkMatchComponentController::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void NetworkMatchComponentController::RoundTickOnceASecond()
     {
-        float& roundTime = ModifyRoundTime();
-        roundTime -= deltaTime;
-        if (roundTime < 0)
+        int16_t& roundTime = ModifyRoundTime();
+        roundTime--; // m_roundTickEvent is configured to tick once a second
+        if (roundTime <= 0)
         {
             EndRound();
         }
-    }
-
-    int NetworkMatchComponentController::GetTickOrder()
-    {
-        return AZ::TICK_PRE_RENDER;
     }
 }

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -16,7 +16,7 @@ namespace MultiplayerSample
 
     void NetworkMatchComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        SetRoundTime(GetRoundDuration());
+        SetRoundTime(RoundTimeSec{ GetRoundDuration() });
         SetRoundNumber(1);
 
         // Tick once a second, this way we can keep the time as an 2 byte integer instead of a float.
@@ -41,7 +41,7 @@ namespace MultiplayerSample
         {
             //Signal event to reset everything
             ++roundNumber;
-            SetRoundTime(GetRoundDuration());
+            SetRoundTime(RoundTimeSec{ GetRoundDuration() });
         }
         else
         {
@@ -52,9 +52,10 @@ namespace MultiplayerSample
 
     void NetworkMatchComponentController::RoundTickOnceASecond()
     {
-        int16_t& roundTime = ModifyRoundTime();
-        roundTime--; // m_roundTickEvent is configured to tick once a second
-        if (roundTime <= 0)
+        // m_roundTickEvent is configured to tick once a second
+        SetRoundTime(RoundTimeSec(GetRoundTime() - 1.f));
+        
+        if (GetRoundTime() <= RoundTimeSec(0.f))
         {
             EndRound();
         }

--- a/Gem/Code/Source/Components/NetworkMatchComponent.h
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.h
@@ -7,30 +7,28 @@
 
 #pragma once
 
-#include <AzCore/Component/TickBus.h>
-#include <Multiplayer/Components/NetBindComponent.h>
-
+#include <AzCore/EBus/ScheduledEvent.h>
 #include <Source/AutoGen/NetworkMatchComponent.AutoComponent.h>
 
 namespace MultiplayerSample
 {
     class NetworkMatchComponentController
         : public NetworkMatchComponentControllerBase
-        , private AZ::TickBus::Handler
     {
     public:
-        NetworkMatchComponentController(NetworkMatchComponent& parent);
+        explicit NetworkMatchComponentController(NetworkMatchComponent& parent);
 
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
         void EndMatch();
         void EndRound();
+
     private:
-        //! AZ::TickBus interface
-        //! @{
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        int GetTickOrder() override;
-        //! @}
+        void RoundTickOnceASecond();
+        AZ::ScheduledEvent m_roundTickEvent{[this]()
+        {
+            RoundTickOnceASecond();
+        }, AZ::Name("NetworkMatchComponentController")};
     };
 }

--- a/Gem/Code/Source/Components/UI/HUDComponent.cpp
+++ b/Gem/Code/Source/Components/UI/HUDComponent.cpp
@@ -31,7 +31,7 @@ namespace MultiplayerSample
         m_roundNumberHandler = AZ::EventHandler<uint16_t>([this](uint16_t value) { this->SetRoundNumberText(value); });
         netMatchComponent->RoundNumberAddEvent(m_roundNumberHandler);
 
-        m_roundTimerHandler = AZ::EventHandler<float>([this](float value) { this->SetRoundTimerText(value); });
+        m_roundTimerHandler = AZ::EventHandler<int16_t>([this](float value) { this->SetRoundTimerText(value); });
         netMatchComponent->RoundTimeAddEvent(m_roundTimerHandler);
     }
 

--- a/Gem/Code/Source/Components/UI/HUDComponent.cpp
+++ b/Gem/Code/Source/Components/UI/HUDComponent.cpp
@@ -31,7 +31,7 @@ namespace MultiplayerSample
             m_roundNumberHandler = AZ::EventHandler<uint16_t>([this](uint16_t value) { SetRoundNumberText(value); });
             netMatchComponent->RoundNumberAddEvent(m_roundNumberHandler);
 
-            m_roundTimerHandler = AZ::EventHandler<int16_t>([this](int16_t value) { SetRoundTimerText(value); });
+            m_roundTimerHandler = AZ::EventHandler<RoundTimeSec>([this](RoundTimeSec value) { SetRoundTimerText(value); });
             netMatchComponent->RoundTimeAddEvent(m_roundTimerHandler);
         }
     }
@@ -97,7 +97,7 @@ namespace MultiplayerSample
         }
     }
 
-    void HUDComponent::SetRoundTimerText(int16_t time)
+    void HUDComponent::SetRoundTimerText(RoundTimeSec time)
     {
         if (m_uiCanvasId.IsValid())
         {
@@ -106,7 +106,7 @@ namespace MultiplayerSample
 
             if (textBoxEntity != nullptr)
             {
-                m_roundTimerText = AZStd::string::format("%d", time);
+                m_roundTimerText = AZStd::string::format("%d", aznumeric_cast<int>(time));
                 UiTextBus::Event(textBoxEntity->GetId(), &UiTextBus::Events::SetText, m_roundTimerText);
             }
         }

--- a/Gem/Code/Source/Components/UI/HUDComponent.h
+++ b/Gem/Code/Source/Components/UI/HUDComponent.h
@@ -53,6 +53,6 @@ namespace MultiplayerSample
         AZStd::string m_roundNumberText = "";
         AZStd::string m_roundTimerText = "";
         AZ::EventHandler<uint16_t> m_roundNumberHandler; 
-        AZ::EventHandler<float> m_roundTimerHandler;
+        AZ::EventHandler<int16_t> m_roundTimerHandler;
     };
 } // namespace MultiplayerSample

--- a/Gem/Code/Source/Components/UI/HUDComponent.h
+++ b/Gem/Code/Source/Components/UI/HUDComponent.h
@@ -44,14 +44,13 @@ namespace MultiplayerSample
         void OnCanvasLoadedIntoEntity(AZ::EntityId uiCanvasEntity) override;
 
         void SetRoundNumberText(uint16_t round);
-        void SetRoundTimerText(float time);
+        void SetRoundTimerText(int16_t time);
     
-    private:
         AZ::EntityId m_uiCanvasId;
         int m_roundNumberId = 0;
         int m_roundTimerId = 0;
-        AZStd::string m_roundNumberText = "";
-        AZStd::string m_roundTimerText = "";
+        AZStd::string m_roundNumberText;
+        AZStd::string m_roundTimerText;
         AZ::EventHandler<uint16_t> m_roundNumberHandler; 
         AZ::EventHandler<int16_t> m_roundTimerHandler;
     };

--- a/Gem/Code/Source/Components/UI/HUDComponent.h
+++ b/Gem/Code/Source/Components/UI/HUDComponent.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/EBus/Event.h>
 #include <LyShine/Bus/World/UiCanvasRefBus.h>
+#include "MultiplayerSampleTypes.h"
 
 namespace MultiplayerSample
 {
@@ -44,7 +45,7 @@ namespace MultiplayerSample
         void OnCanvasLoadedIntoEntity(AZ::EntityId uiCanvasEntity) override;
 
         void SetRoundNumberText(uint16_t round);
-        void SetRoundTimerText(int16_t time);
+        void SetRoundTimerText(RoundTimeSec time);
     
         AZ::EntityId m_uiCanvasId;
         int m_roundNumberId = 0;
@@ -52,6 +53,6 @@ namespace MultiplayerSample
         AZStd::string m_roundNumberText;
         AZStd::string m_roundTimerText;
         AZ::EventHandler<uint16_t> m_roundNumberHandler; 
-        AZ::EventHandler<int16_t> m_roundTimerHandler;
+        AZ::EventHandler<RoundTimeSec> m_roundTimerHandler;
     };
 } // namespace MultiplayerSample

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -42,6 +42,8 @@ namespace MultiplayerSample
         Crouching,
         COUNT = Crouching + 1
     };
+
+    using RoundTimeSec = AzNetworking::QuantizedValues<1, 2, 0, 3600>; // 1 hour max round duration
 }
 
 namespace AZ


### PR DESCRIPTION
- Added a new quantized type for game round time
- Reduced traffic requirement for game match time from .63kpbs to 0.03kpbs
- Confirmed that UI for the match time remains the same as before this change

Before:
![image](https://user-images.githubusercontent.com/5432499/182245062-4d68cf0f-f06a-4bbb-844c-6081fb9d79c4.png)

After:
![image](https://user-images.githubusercontent.com/5432499/182245076-3ff960ad-6942-4338-ae18-af733c896e7a.png)
