### PR TITLE
Add player respawn on armor depletion and match end

### DIFF
--- a/Gem/Code/Include/PlayerMatchLifecycleBus.h
+++ b/Gem/Code/Include/PlayerMatchLifecycleBus.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <Multiplayer/MultiplayerTypes.h>
+
+namespace MultiplayerSample
+{
+    class PlayerMatchLifecycleNotifications : public AZ::EBusTraits
+    {
+    public:
+        virtual ~PlayerMatchLifecycleNotifications() = default;
+
+        virtual void OnPlayerArmorZero([[maybe_unused]] Multiplayer::NetEntityId playerEntity) {}
+    };
+
+    using PlayerMatchLifecycleBus = AZ::EBus<PlayerMatchLifecycleNotifications>;
+}

--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -22,6 +22,7 @@
 
     <ArchetypeProperty Type="float"  Name="RoundDuration"  Init="120.f" ExposeToEditor="true" Description="Total time of a round in seconds" />
     <ArchetypeProperty Type="uint16_t"  Name="TotalRounds"  Init="3" ExposeToEditor="true" Description="Total number of rounds" />
+	<ArchetypeProperty Type="uint16_t"  Name="RespawnPenaltyPercent" Init="50" ExposeToEditor="true" Description="Percent of score to deduct on armor depletion"/>
 
     <RemoteProcedure Name="RPC_EndMatch" InvokeFrom="Authority" HandleOn="Client" IsPublic="false" IsReliable="true"
                     GenerateEventBindings="" Description="Send match over event and results">
@@ -38,3 +39,4 @@
         <Param Type="Multiplayer::NetEntityId" Name="PlayerEntity"/>
     </RemoteProcedure>
 </Component>
+ 

--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -22,7 +22,7 @@
 
     <ArchetypeProperty Type="float"  Name="RoundDuration"  Init="120.f" ExposeToEditor="true" Description="Total time of a round in seconds" />
     <ArchetypeProperty Type="uint16_t"  Name="TotalRounds"  Init="3" ExposeToEditor="true" Description="Total number of rounds" />
-	<ArchetypeProperty Type="uint16_t"  Name="RespawnPenaltyPercent" Init="50" ExposeToEditor="true" Description="Percent of score to deduct on armor depletion"/>
+    <ArchetypeProperty Type="uint16_t"  Name="RespawnPenaltyPercent" Init="50" ExposeToEditor="true" Description="Percent of score to deduct on armor depletion"/>
 
     <RemoteProcedure Name="RPC_EndMatch" InvokeFrom="Authority" HandleOn="Client" IsPublic="false" IsReliable="true"
                     GenerateEventBindings="" Description="Send match over event and results">

--- a/Gem/Code/Source/AutoGen/PlayerIdentityComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/PlayerIdentityComponent.AutoComponent.xml
@@ -25,5 +25,6 @@
 
     <RemoteProcedure Name="RPC_ResetPlayerState" InvokeFrom="Server" HandleOn="Authority" IsPublic="true" IsReliable="true"
                      GenerateEventBindings="false" Description="Resets the player's state.">
+        <Param Type="PlayerResetOptions" Name="ResetOptions"/>
     </RemoteProcedure>
 </Component>

--- a/Gem/Code/Source/Components/Multiplayer/PlayerArmorComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerArmorComponent.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <UiPlayerArmorBus.h>
+#include <PlayerMatchLifecycleBus.h>
 #include <Components/NetworkHealthComponent.h>
 #include <Source/Components/Multiplayer/PlayerArmorComponent.h>
 
@@ -18,10 +19,7 @@ namespace MultiplayerSample
 
     void PlayerArmorComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        if (IsAutonomous())
-        {
-            GetNetworkHealthComponentController()->GetParent().HealthAddEvent(m_changedHandler);
-        }
+        GetNetworkHealthComponentController()->GetParent().HealthAddEvent(m_changedHandler);
 
         if (IsAuthority())
         {
@@ -37,5 +35,9 @@ namespace MultiplayerSample
     void PlayerArmorComponentController::OnAmountChanged(float armor)
     {
         UiPlayerArmorNotificationBus::Broadcast(&UiPlayerArmorNotificationBus::Events::OnPlayerArmorChanged, armor, GetStartingArmor());
+        if (armor <= 0)
+        {
+            PlayerMatchLifecycleBus::Broadcast(&PlayerMatchLifecycleNotifications::OnPlayerArmorZero, GetNetEntityId());
+        }
     }
 }

--- a/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.cpp
@@ -69,10 +69,16 @@ namespace MultiplayerSample
         SetPlayerName(newPlayerName);
     }
 
-    void PlayerIdentityComponentController::HandleRPC_ResetPlayerState([[maybe_unused]] AzNetworking::IConnection* invokingConnection)
+    void PlayerIdentityComponentController::HandleRPC_ResetPlayerState([[maybe_unused]] AzNetworking::IConnection* invokingConnection, const PlayerResetOptions& resetOptions)
     {
-        GetNetworkHealthComponentController()->SetHealth(GetNetworkHealthComponentController()->GetMaxHealth());
-        GetPlayerCoinCollectorComponentController()->SetCoinsCollected(0);
-        PlayerIdentityComponentControllerBase::HandleRPC_ResetPlayerState(invokingConnection);
+        if (resetOptions.m_resetArmor)
+        {
+            GetNetworkHealthComponentController()->SetHealth(GetNetworkHealthComponentController()->GetMaxHealth());
+        }
+        auto currentCoins = GetPlayerCoinCollectorComponentController()->GetCoinsCollected();
+        float coinsToDeduct = currentCoins * (resetOptions.m_coinPenalty * 0.01f);
+
+        GetPlayerCoinCollectorComponentController()->SetCoinsCollected(currentCoins - aznumeric_cast<uint16_t>(coinsToDeduct));
+        PlayerIdentityComponentControllerBase::HandleRPC_ResetPlayerState(invokingConnection, resetOptions);
     }
 }

--- a/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.h
@@ -37,6 +37,6 @@ namespace MultiplayerSample
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
         void HandleRPC_AssignPlayerName(AzNetworking::IConnection* invokingConnection, const PlayerNameString& newPlayerName) override;
-        void HandleRPC_ResetPlayerState(AzNetworking::IConnection* invokingConnection) override;
+        void HandleRPC_ResetPlayerState(AzNetworking::IConnection* invokingConnection, const PlayerResetOptions& resetOptions) override;
     };
 }

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -12,7 +12,10 @@
 #include <GameState/GameStatePreparingMatch.h>
 #include <Source/Components/Multiplayer/MatchPlayerCoinsComponent.h>
 #include <Source/Components/Multiplayer/PlayerIdentityComponent.h>
+#include <Source/Components/NetworkTeleportCompatibleComponent.h>
+#include <Source/Components/NetworkHealthComponent.h>
 #include <Source/Components/NetworkMatchComponent.h>
+#include <Source/Spawners/IPlayerSpawner.h>
 #include <GameState/GameStateRequestBus.h>
 #include <GameState/GameStateWaitingForPlayers.h>
 
@@ -89,10 +92,14 @@ namespace MultiplayerSample
             });
 
         GameState::GameStateRequests::CreateAndPushNewOverridableGameStateOfType<GameStateWaitingForPlayers>();
+
+        PlayerMatchLifecycleBus::Handler::BusConnect();
     }
 
     void NetworkMatchComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        PlayerMatchLifecycleBus::Handler::BusDisconnect();
+
         GameState::GameStateRequestBus::Broadcast(&GameState::GameStateRequestBus::Events::PopAllGameStates);
 
         GameState::GameStateRequests::RemoveGameStateFactoryOverrideForType<GameStateWaitingForPlayers>();
@@ -133,7 +140,7 @@ namespace MultiplayerSample
                 if (PlayerIdentityComponent* identity = playerHandle.GetEntity()->FindComponent<PlayerIdentityComponent>())
                 {
                     state.m_playerName = identity->GetPlayerName();
-                    identity->RPC_ResetPlayerState();
+                    RespawnPlayer(playerNetEntity, PlayerResetOptions{ true, 100 });
                 }
                 if (const NetworkHealthComponent* armor = playerHandle.GetEntity()->FindComponent<NetworkHealthComponent>())
                 {
@@ -193,6 +200,21 @@ namespace MultiplayerSample
         }
     }
 
+    void NetworkMatchComponentController::OnPlayerArmorZero(Multiplayer::NetEntityId playerEntity)
+    {
+        const auto playerIterator = AZStd::find(m_players.begin(), m_players.end(), playerEntity);
+        const auto playerHandle = Multiplayer::GetNetworkEntityManager()->GetEntity(playerEntity);
+        if ((playerIterator != m_players.end()) && playerHandle.Exists())
+        {
+            RespawnPlayer(playerEntity, PlayerResetOptions{ true, GetRespawnPenaltyPercent() });
+        }
+        else
+        {
+            AZ_Warning("NetworkMatchComponentController", false, "An unknown player reported depleted armor: %llu", aznumeric_cast<AZ::u64>(playerEntity));
+        }
+        
+    }
+
     void NetworkMatchComponentController::RoundTickOnceASecond()
     {
         // m_roundTickEvent is configured to tick once a second
@@ -221,4 +243,31 @@ namespace MultiplayerSample
 
         m_nextPlayerId++;
     }
+
+    void NetworkMatchComponentController::RespawnPlayer(Multiplayer::NetEntityId playerEntity, PlayerResetOptions resets)
+    {
+        const auto playerHandle = Multiplayer::GetNetworkEntityManager()->GetEntity(playerEntity);
+        if (playerHandle.Exists())
+        {
+            // reset state
+            if (PlayerIdentityComponent* identity = playerHandle.GetEntity()->FindComponent<PlayerIdentityComponent>())
+            {
+                identity->RPC_ResetPlayerState(resets);
+            }
+
+            // move to valid respawn point
+            if (NetworkTeleportCompatibleComponent* teleport = playerHandle.GetEntity()->FindComponent<NetworkTeleportCompatibleComponent>())
+            {
+                AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> entityParams = 
+                    AZ::Interface<IPlayerSpawner>::Get()->GetNextPlayerSpawn();
+
+                teleport->Teleport(entityParams.second.GetTranslation());
+            }
+        }
+        else
+        {
+            AZ_Warning("NetworkMatchComponentController", false, "Attempted respawn of an unknown player: %llu", aznumeric_cast<AZ::u64>(playerEntity));
+        }
+    }
+
 }

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -203,10 +203,12 @@ namespace MultiplayerSample
     void NetworkMatchComponentController::OnPlayerArmorZero(Multiplayer::NetEntityId playerEntity)
     {
         const auto playerIterator = AZStd::find(m_players.begin(), m_players.end(), playerEntity);
-        const auto playerHandle = Multiplayer::GetNetworkEntityManager()->GetEntity(playerEntity);
-        if ((playerIterator != m_players.end()) && playerHandle.Exists())
+        if (playerIterator != m_players.end())
         {
-            RespawnPlayer(playerEntity, PlayerResetOptions{ true, GetRespawnPenaltyPercent() });
+            if (Multiplayer::ConstNetworkEntityHandle playerHandle = Multiplayer::GetNetworkEntityManager()->GetEntity(playerEntity))
+            {
+                RespawnPlayer(playerEntity, PlayerResetOptions{ true, GetRespawnPenaltyPercent() });
+            }
         }
         else
         {

--- a/Gem/Code/Source/Components/NetworkMatchComponent.h
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <PlayerIdentityBus.h>
+#include <PlayerMatchLifecycleBus.h>
 #include <AzCore/EBus/ScheduledEvent.h>
 #include <Source/AutoGen/NetworkMatchComponent.AutoComponent.h>
 
@@ -21,7 +22,7 @@ namespace MultiplayerSample
         AZ_MULTIPLAYER_COMPONENT(MultiplayerSample::NetworkMatchComponent, s_networkMatchComponentConcreteUuid, MultiplayerSample::NetworkMatchComponentBase);
 
         static void Reflect(AZ::ReflectContext* context);
-        
+
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
@@ -37,12 +38,18 @@ namespace MultiplayerSample
 
     class NetworkMatchComponentController
         : public NetworkMatchComponentControllerBase
+        , public PlayerMatchLifecycleBus::Handler
     {
     public:
         explicit NetworkMatchComponentController(NetworkMatchComponent& parent);
 
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+        //! PlayerMatchLifecycleBus overrides
+        //! @{
+        void OnPlayerArmorZero(Multiplayer::NetEntityId playerEntity) override;
+        //! )@
 
         void StartMatch();
 
@@ -65,5 +72,7 @@ namespace MultiplayerSample
         //! A temporary way to assign player identities, such as player names.
         void AssignPlayerIdentity(Multiplayer::NetEntityId playerEntity);
         int m_nextPlayerId = 1;
+
+        void RespawnPlayer(Multiplayer::NetEntityId playerEntity, PlayerResetOptions resets);
     };
 }

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -114,6 +114,19 @@ namespace MultiplayerSample
     {
         return m_winningPlayerName != rhs.m_winningPlayerName;
     }
+
+    struct PlayerResetOptions
+    {
+        bool m_resetArmor = false;
+        uint16_t m_coinPenalty = 0;
+        bool Serialize(AzNetworking::ISerializer& serializer);
+    };
+
+    inline bool PlayerResetOptions::Serialize(AzNetworking::ISerializer& serializer)
+    {
+        return serializer.Serialize(m_resetArmor, "resetArmor")
+            && serializer.Serialize(m_coinPenalty, "coinPenalty");
+    }
 }
 
 namespace AZ

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -10,6 +10,7 @@ set(FILES
     Include/NetworkPrefabSpawnerInterface.h
     Include/PlayerCoinCollectorBus.h
     Include/PlayerIdentityBus.h
+    Include/PlayerMatchLifecycleBus.h
     Include/UiCoinCountBus.h
     Include/UiGameOverBus.h
     Include/UiPlayerArmorBus.h


### PR DESCRIPTION
Adds respawn behavior when player armor runs out and adds respawn point movement at match end.

* on match end, health & coins are reset as before, plus player is moved to known spawning location.
* when armor (health) is depleted, player will now move to respawn point, get health reset, and lose some configurable % of their coins (see new archetype property on `NetworkMatchComponent`, defaults to 50%)

NOTE: attempt to subscribe to `PlayerMatchLifecycle` events on `NetworkMatchComponent` and trigger behavior via RPC to the controller (similar to player de/activate flow in that component) were not successful. This implementation would better handle differences in server authority over players vs. `NetworkMatchComponent`. 
Issue cut to track: https://github.com/o3de/o3de-multiplayersample/issues/178

## Testing

* Losing all armor to cannon fire causes respawn teleport, health regen, and correct % of coin loss
* End of match reset now also results player moving to respawn point.

_before armor loss respawn_
![image](https://user-images.githubusercontent.com/34254888/185715822-6cbd8ca5-f062-4b29-a5cf-6666de1b03a6.png)

_after respawn_ 
![image](https://user-images.githubusercontent.com/34254888/185715860-a56a436d-b289-4a37-89d5-374f52d43a68.png)

