### PR TITLE
Added knockback to players and configuration for energy cannons and energy balls

### DIFF
--- a/Gem/Code/Include/PlayerKnockbackBus.h
+++ b/Gem/Code/Include/PlayerKnockbackBus.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace MultiplayerSample
+{
+    class PlayerKnockbackNotifications : public AZ::ComponentBus
+    {
+    public:
+        ~PlayerKnockbackNotifications() override = default;
+
+        virtual void OnPlayerKnockback(
+            [[maybe_unused]] const AZ::Vector3& fromPosition,
+            [[maybe_unused]] const AZ::Vector3& PlayerKnockbackDirection) {}
+    };
+
+    using PlayerKnockbackNotificationBus = AZ::EBus<PlayerKnockbackNotifications>;
+}

--- a/Gem/Code/Source/AutoGen/EnergyBallComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/EnergyBallComponent.AutoComponent.xml
@@ -11,11 +11,6 @@
     <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
     <ComponentRelation Constraint="Required" HasController="true" Name="NetworkRigidBodyComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkRigidBodyComponent.h" />
 
-    <ArchetypeProperty Type="float" Name="Speed" Init="15.f" ExposeToEditor="true" Suffix="world units per second"
-                       Description="The speed of the energy ball" />
-    <ArchetypeProperty Type="float" Name="DamageOnHit" Init="5.f" ExposeToEditor="true" Suffix="armor units"
-                       Description="Reduces a player hit by the energy ball by a specified armor unit amount." />
-
     <RemoteProcedure Name="RPC_LaunchBall" InvokeFrom="Server" HandleOn="Authority" IsPublic="true" IsReliable="true"
         GenerateEventBindings="true" Description="Launching an energy from a specified position in a specified direction.">
         <Param Type="AZ::Vector3" Name="StartingPosition"/>

--- a/Gem/Code/Source/AutoGen/EnergyCannonComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/EnergyCannonComponent.AutoComponent.xml
@@ -12,6 +12,4 @@
 
     <ArchetypeProperty Type="AZ::EntityId" Name="EnergyBallEntity" ExposeToEditor="true"
                        Description="The entity representing an energy ball." />
-    <ArchetypeProperty Type="AZ::TimeMs" Name="FiringPeriod" Init="AZ::TimeMs{3000}" ExposeToEditor="true" Suffix="milliseconds"
-                       Description="How quickly to fire another energy ball from the cannon." />
 </Component>

--- a/Gem/Code/Source/AutoGen/PlayerKnockbackEffectComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/PlayerKnockbackEffectComponent.AutoComponent.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<Component
+    Name="PlayerKnockbackEffectComponent"
+    Namespace="MultiplayerSample"
+    OverrideComponent="false"
+    OverrideController="true"
+    OverrideInclude="Source/Components/Multiplayer/PlayerKnockbackEffectComponent.h"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkCharacterComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkCharacterComponent.h" />
+
+    <RemoteProcedure Name="RPC_Knockback" InvokeFrom="Server" HandleOn="Authority" IsPublic="true" IsReliable="true"
+                     GenerateEventBindings="false" Description="Shoves an object in a specified direction.">\
+	    <Param Type="AZ::Vector3" Name="Direction"/>
+    </RemoteProcedure>
+</Component>

--- a/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.cpp
@@ -5,8 +5,10 @@
  *
  */
 
+#include <MultiplayerSampleTypes.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
@@ -23,6 +25,8 @@ namespace MultiplayerSample
 
     void EnergyBallComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        LoadEnergyBallSettings();
+
         AzPhysics::RigidBody* body = nullptr;
         Physics::RigidBodyRequestBus::EventResult(body, GetEntityId(), &Physics::RigidBodyRequests::GetRigidBody);
         if (body)
@@ -39,15 +43,17 @@ namespace MultiplayerSample
     void EnergyBallComponentController::HandleRPC_LaunchBall([[maybe_unused]] AzNetworking::IConnection* invokingConnection,
         const AZ::Vector3& startingPosition, const AZ::Vector3& direction)
     {
+        m_direction = direction;
+
         using RigidBodyBus = Physics::RigidBodyRequestBus;
         RigidBodyBus::Event(GetEntityId(), &RigidBodyBus::Events::DisablePhysics);
 
         // move self and increment resetCount to prevent transform interpolation
-        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTranslation, startingPosition);        
+        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTranslation, startingPosition);
         GetNetworkTransformComponentController()->ModifyResetCount()++;
-        
+
         RigidBodyBus::Event(GetEntityId(), &RigidBodyBus::Events::EnablePhysics);
-        RigidBodyBus::Event(GetEntityId(), &RigidBodyBus::Events::SetLinearVelocity, direction * GetSpeed());
+        RigidBodyBus::Event(GetEntityId(), &RigidBodyBus::Events::SetLinearVelocity, direction * aznumeric_cast<float>(m_speed));
     }
 
     void EnergyBallComponentController::HideEnergyBall()
@@ -70,11 +76,35 @@ namespace MultiplayerSample
             {
                 if (NetworkHealthComponent* health = target->FindComponent<NetworkHealthComponent>())
                 {
-                    health->SendHealthDelta(-GetDamageOnHit());
+                    health->SendHealthDelta(aznumeric_cast<float>(-m_armorDamage));
                 }
+
+                TryKnockbackPlayer(target);
             }
 
             HideEnergyBall();
+        }
+    }
+
+    void EnergyBallComponentController::LoadEnergyBallSettings()
+    {
+        if (const auto registry = AZ::SettingsRegistry::Get())
+        {
+            registry->Get(m_knockbackDistance, KnockbackDistanceByEnergyBallSetting);
+            registry->Get(m_speed, EnergyBallSpeedSetting);
+            registry->Get(m_armorDamage, EnergyBallArmorDamageSetting);
+        }
+    }
+
+    void EnergyBallComponentController::TryKnockbackPlayer(AZ::Entity* target)
+    {
+        if (PlayerKnockbackEffectComponent* effect = target->FindComponent<PlayerKnockbackEffectComponent>())
+        {
+            const AZ::Vector3 direction = m_direction.GetNormalized();
+            if (m_knockbackDistance > 0.0)
+            {
+                effect->RPC_Knockback(direction * aznumeric_cast<float>(m_knockbackDistance));
+            }
         }
     }
 }

--- a/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.h
@@ -25,6 +25,7 @@ namespace MultiplayerSample
 
     private:
         void HideEnergyBall();
+        void TryKnockbackPlayer(AZ::Entity* target);
 
         void OnCollisionBegin(const AzPhysics::CollisionEvent& collisionEvent);
         AzPhysics::SimulatedBodyEvents::OnCollisionBegin::Handler m_collisionHandler{ [this](
@@ -32,5 +33,11 @@ namespace MultiplayerSample
         {
             OnCollisionBegin(collisionEvent);
         } };
+
+        void LoadEnergyBallSettings();
+        AZ::Vector3 m_direction = AZ::Vector3::CreateZero();
+        double m_knockbackDistance = 0.0;
+        double m_speed = 0.0;
+        AZ::s64 m_armorDamage = 0;
     };
 }

--- a/Gem/Code/Source/Components/Multiplayer/EnergyCannonComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/EnergyCannonComponent.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <MultiplayerSampleTypes.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <Source/Components/Multiplayer/EnergyBallComponent.h>
@@ -19,7 +20,15 @@ namespace MultiplayerSample
 
     void EnergyCannonComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        m_firingEvent.Enqueue(GetFiringPeriod(), true);
+        if (const auto registry = AZ::SettingsRegistry::Get())
+        {
+            AZ::s64 firingPeriod = 0;
+            registry->Get(firingPeriod, EnergyCannonFiringPeriodSetting);
+            if (firingPeriod > 0)
+            {
+                m_firingEvent.Enqueue(AZ::TimeMs{ firingPeriod }, true);
+            }
+        }
     }
 
     void EnergyCannonComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)

--- a/Gem/Code/Source/Components/Multiplayer/PlayerKnockbackEffectComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerKnockbackEffectComponent.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PlayerKnockbackBus.h>
+#include <Multiplayer/Components/NetworkCharacterComponent.h>
+#include <Multiplayer/Components/NetworkTransformComponent.h>
+#include <Source/Components/Multiplayer/PlayerKnockbackEffectComponent.h>
+
+namespace MultiplayerSample
+{
+    PlayerKnockbackEffectComponentController::PlayerKnockbackEffectComponentController(PlayerKnockbackEffectComponent& parent)
+        : PlayerKnockbackEffectComponentControllerBase(parent)
+    {
+    }
+
+    void PlayerKnockbackEffectComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void PlayerKnockbackEffectComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void PlayerKnockbackEffectComponentController::HandleRPC_Knockback([[maybe_unused]] AzNetworking::IConnection* invokingConnection,
+        const AZ::Vector3& direction)
+    {
+        const AZ::Vector3& position = GetNetworkTransformComponentController()->GetTranslation();
+        PlayerKnockbackNotificationBus::Event(GetEntityId(), &PlayerKnockbackNotificationBus::Events::OnPlayerKnockback, position, direction);
+
+        // Spread out the move to avoid issues in a physical simulation.
+        const float largestPossibleStep = 0.25f;
+        const int steps = aznumeric_cast<int>(direction.GetLength() / largestPossibleStep) + 1;
+        if (steps > 0)
+        {
+            const float deltaTime = 1.f / aznumeric_cast<float>(steps);
+            for (int i = 0; i < steps; ++i)
+            {
+                GetNetworkCharacterComponentController()->TryMoveWithVelocity(direction, deltaTime);
+            }
+        }
+    }
+}

--- a/Gem/Code/Source/Components/Multiplayer/PlayerKnockbackEffectComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerKnockbackEffectComponent.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Source/AutoGen/PlayerKnockbackEffectComponent.AutoComponent.h>
+
+namespace MultiplayerSample
+{
+    class PlayerKnockbackEffectComponentController
+        : public PlayerKnockbackEffectComponentControllerBase
+    {
+    public:
+        explicit PlayerKnockbackEffectComponentController(PlayerKnockbackEffectComponent& parent);
+
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+        void HandleRPC_Knockback(AzNetworking::IConnection* invokingConnection, const AZ::Vector3& direction) override;
+    };
+}

--- a/Gem/Code/Source/GameState/GameStateMatchInProgress.cpp
+++ b/Gem/Code/Source/GameState/GameStateMatchInProgress.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <GameState/GameStateMatchEnded.h>
 #include <GameState/GameStateRequestBus.h>
 #include <Source/GameState/GameStateMatchInProgress.h>
 

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -14,7 +14,7 @@
 namespace MultiplayerSample
 {
     constexpr AZStd::string_view WinningCoinCountSetting = "/MultiplayerSample/Settings/WinningCoinCount";
-    constexpr AZStd::string_view KnockbackDistanceByEnergyBallSetting = "/MultiplayerSample/Settings/EnergyBall/KnockbackDistance";
+    constexpr AZStd::string_view KnockbackDistanceByEnergyBallSetting = "/MultiplayerSample/Settings/EnergyBall/KnockbackDistanceMeters";
     constexpr AZStd::string_view EnergyBallSpeedSetting = "/MultiplayerSample/Settings/EnergyBall/Speed";
     constexpr AZStd::string_view EnergyBallArmorDamageSetting = "/MultiplayerSample/Settings/EnergyBall/ArmorDamage";
     constexpr AZStd::string_view EnergyCannonFiringPeriodSetting = "/MultiplayerSample/Settings/EnergyCannon/FiringPeriodMilliseconds";

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -14,6 +14,10 @@
 namespace MultiplayerSample
 {
     constexpr AZStd::string_view WinningCoinCountSetting = "/MultiplayerSample/Settings/WinningCoinCount";
+    constexpr AZStd::string_view KnockbackDistanceByEnergyBallSetting = "/MultiplayerSample/Settings/EnergyBall/KnockbackDistance";
+    constexpr AZStd::string_view EnergyBallSpeedSetting = "/MultiplayerSample/Settings/EnergyBall/Speed";
+    constexpr AZStd::string_view EnergyBallArmorDamageSetting = "/MultiplayerSample/Settings/EnergyBall/ArmorDamage";
+    constexpr AZStd::string_view EnergyCannonFiringPeriodSetting = "/MultiplayerSample/Settings/EnergyCannon/FiringPeriodMilliseconds";
 
     using StickAxis = AzNetworking::QuantizedValues<1, 1, -1, 1>;
     using MouseAxis = AzNetworking::QuantizedValues<1, 2, -1, 1>;

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -6,6 +6,7 @@
 #
 
 set(FILES
+    Include/PlayerKnockbackBus.h
     Include/MatchPlayerCoinsBus.h
     Include/NetworkPrefabSpawnerInterface.h
     Include/PlayerCoinCollectorBus.h
@@ -15,9 +16,9 @@ set(FILES
     Include/UiGameOverBus.h
     Include/UiPlayerArmorBus.h
 
-    Source/AutoGen/MatchPlayerCoinsComponent.AutoComponent.xml
     Source/AutoGen/EnergyBallComponent.AutoComponent.xml
     Source/AutoGen/EnergyCannonComponent.AutoComponent.xml
+    Source/AutoGen/MatchPlayerCoinsComponent.AutoComponent.xml
     Source/AutoGen/NetworkAiComponent.AutoComponent.xml
     Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml
     Source/AutoGen/NetworkCoinComponent.AutoComponent.xml
@@ -28,18 +29,19 @@ set(FILES
     Source/AutoGen/NetworkPlayerSpawnerComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
+    Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
+    Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
     Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml
     Source/AutoGen/NetworkStressTestComponent.AutoComponent.xml
-    Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
-    Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
-    Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
-    Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
     Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
+    Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
+    Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
     Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
     Source/AutoGen/PlayerArmorComponent.AutoComponent.xml
     Source/AutoGen/PlayerCoinCollectorComponent.AutoComponent.xml
     Source/AutoGen/PlayerIdentityComponent.AutoComponent.xml
+    Source/AutoGen/PlayerKnockbackEffectComponent.AutoComponent.xml
 
     Source/Components/ExampleFilteredEntityComponent.h
     Source/Components/ExampleFilteredEntityComponent.cpp
@@ -99,6 +101,8 @@ set(FILES
     Source/Components/Multiplayer/PlayerCoinCollectorComponent.h
     Source/Components/Multiplayer/PlayerIdentityComponent.cpp
     Source/Components/Multiplayer/PlayerIdentityComponent.h
+    Source/Components/Multiplayer/PlayerKnockbackEffectComponent.cpp
+    Source/Components/Multiplayer/PlayerKnockbackEffectComponent.h
     Source/Components/Multiplayer/EnergyBallComponent.cpp
     Source/Components/Multiplayer/EnergyBallComponent.h
     Source/Components/Multiplayer/EnergyCannonComponent.cpp

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -11,10 +11,6 @@
                 "$type": "EditorDisabledCompositionComponent",
                 "Id": 10732697195551847781
             },
-            "Component_[1098481335074499299]": {
-                "$type": "SelectionComponent",
-                "Id": 1098481335074499299
-            },
             "Component_[14001194199437502546]": {
                 "$type": "EditorPendingCompositionComponent",
                 "Id": 14001194199437502546
@@ -87,10 +83,6 @@
                     "m_template": {
                         "$type": "MultiplayerSample::NetworkHealthComponent"
                     }
-                },
-                "Component_[11366312871180321311]": {
-                    "$type": "SelectionComponent",
-                    "Id": 11366312871180321311
                 },
                 "Component_[11573337348143243531]": {
                     "$type": "GenericComponentWrapper",
@@ -171,6 +163,13 @@
                 "Component_[17993245065130330388]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17993245065130330388
+                },
+                "Component_[1825823955420198768]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1825823955420198768,
+                    "m_template": {
+                        "$type": "MultiplayerSample::PlayerKnockbackEffectComponent"
+                    }
                 },
                 "Component_[2596368806843971783]": {
                     "$type": "GenericComponentWrapper",

--- a/Registry/multiplayersample.setreg
+++ b/Registry/multiplayersample.setreg
@@ -1,7 +1,15 @@
 {
     "MultiplayerSample": {
         "Settings": {
-            "WinningCoinCount": 3
+            "WinningCoinCount": 3,
+            "EnergyBall": {
+                "KnockbackDistance": 2.0,
+                "Speed": 15.0,
+                "ArmorDamage": 10
+            },
+            "EnergyCannon": {
+                "FiringPeriodMilliseconds": 2000
+            }
         }
     }
 }

--- a/Registry/multiplayersample.setreg
+++ b/Registry/multiplayersample.setreg
@@ -3,7 +3,7 @@
         "Settings": {
             "WinningCoinCount": 3,
             "EnergyBall": {
-                "KnockbackDistance": 2.0,
+                "KnockbackDistanceMeters": 2.0,
                 "Speed": 15.0,
                 "ArmorDamage": 10
             },


### PR DESCRIPTION
- Added new configuration

```
{
    "MultiplayerSample": {
        "Settings": {
            "WinningCoinCount": 3,
            "EnergyBall": {
                "KnockbackDistance": 2.0,
                "Speed": 15.0,
                "ArmorDamage": 10
            },
            "EnergyCannon": {
                "FiringPeriodMilliseconds": 2000
            }
        }
    }
}
```
- Added a knockback effect to players when hit by an energy ball

Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>