### PR TITLE
First pass at jump pads

### DIFF
--- a/Gem/Code/Source/AutoGen/JumpPadComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/JumpPadComponent.AutoComponent.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<Component
+    Name="JumpPadComponent"
+    Namespace="MultiplayerSample"
+    OverrideComponent="true"
+    OverrideController="true"
+    OverrideInclude="Source/Components/Multiplayer/JumpPadComponent.h"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+
+    <ArchetypeProperty Type="float" Name="JumpVelocity" ExposeToEditor="true"
+                       Description="Velocity magnitude to apply to an object entering the jump pad." />
+    <ArchetypeProperty Type="AZ::TimeMs" Name="JumpDuration" ExposeToEditor="true"
+                       Description="Time in milliseconds of the upward jump effect" />
+</Component>

--- a/Gem/Code/Source/AutoGen/PlayerJumpPadEffectComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/PlayerJumpPadEffectComponent.AutoComponent.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<Component
+    Name="PlayerJumpPadEffectComponent"
+    Namespace="MultiplayerSample"
+    OverrideComponent="true"
+    OverrideController="true"
+    OverrideInclude="Source/Components/Multiplayer/PlayerJumpPadEffectComponent.h"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+    <ComponentRelation Constraint="Required" HasController="true" Name="NetworkCharacterComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkCharacterComponent.h" />
+
+    <ArchetypeProperty Type="float" Name="Gravity" ExposeToEditor="true"
+                       Description="Gravity along negative Z axis" />
+
+	<NetworkInput Type="bool" Name="JumpPadEffect" Init="false" />
+    <NetworkInput Type="AZ::Vector3" Name="JumpPadVector" Init="AZ::Vector3::CreateZero()" />
+
+    <RemoteProcedure Name="RPC_ApplyJumpPadEffect" InvokeFrom="Server" HandleOn="Authority" IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="A player stepped on a jump pad.">
+        <Param Type="AZ::Vector3" Name="JumpVelocity" />
+        <Param Type="AZ::TimeMs" Name="EffectDuration" />
+    </RemoteProcedure>
+
+    <RemoteProcedure Name="RPC_StartJump" InvokeFrom="Authority" HandleOn="Autonomous" IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Start a jump effect on the player.">
+        <Param Type="AZ::Vector3" Name="JumpVelocity" />
+        <Param Type="AZ::TimeMs" Name="EffectDuration" />
+    </RemoteProcedure>
+</Component>

--- a/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzFramework/Physics/PhysicsSystem.h>
+#include <Source/Components/Multiplayer/JumpPadComponent.h>
+
+#include "PlayerJumpPadEffectComponent.h"
+
+namespace MultiplayerSample
+{
+    void JumpPadComponent::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<JumpPadComponent, JumpPadComponentBase>()
+                ->Version(1);
+        }
+        JumpPadComponentBase::Reflect(context);
+    }
+
+    void JumpPadComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        JumpPadComponentBase::GetRequiredServices(required);
+        required.push_back(AZ_CRC_CE("PhysicsTriggerService"));
+    }
+
+    void JumpPadComponent::OnInit()
+    {
+    }
+
+    void JumpPadComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void JumpPadComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+
+    JumpPadComponentController::JumpPadComponentController(JumpPadComponent& parent)
+        : JumpPadComponentControllerBase(parent)
+    {
+    }
+
+    void JumpPadComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        if (physicsSystem)
+        {
+            const AZ::EntityId selfId = GetEntity()->GetId();
+            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(selfId);
+            AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
+                sceneHandle, bodyHandle, m_enterTrigger);
+        }
+    }
+
+    void JumpPadComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        m_enterTrigger.Disconnect();
+    }
+
+    void JumpPadComponentController::OnTriggerEnter([[maybe_unused]] AzPhysics::SimulatedBodyHandle bodyHandle,
+        const AzPhysics::TriggerEvent& triggerEvent)
+    {
+        if (triggerEvent.m_otherBody)
+        {
+            AZ_Printf(__FUNCTION__, "an object entered the jump pad");
+
+            AZ::Entity* collidingEntity = nullptr;
+            AZ::EntityId collidingEntityId = triggerEvent.m_otherBody->GetEntityId();
+            AZ::ComponentApplicationBus::BroadcastResult(collidingEntity,
+                &AZ::ComponentApplicationBus::Events::FindEntity, collidingEntityId);
+            if (collidingEntity)
+            {
+                if (PlayerJumpPadEffectComponent* effect = collidingEntity->FindComponent<PlayerJumpPadEffectComponent>())
+                {
+                    const AZ::Quaternion worldQuaternion = GetEntity()->GetTransform()->GetWorldRotationQuaternion();
+                    const AZ::Vector3 jumpVelocity = worldQuaternion.TransformVector(AZ::Vector3::CreateAxisY(GetJumpVelocity()));
+
+                    effect->RPC_ApplyJumpPadEffect(jumpVelocity, GetJumpDuration());
+                }
+            }
+        }
+    }
+}

--- a/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.cpp
@@ -71,8 +71,6 @@ namespace MultiplayerSample
     {
         if (triggerEvent.m_otherBody)
         {
-            AZ_Printf(__FUNCTION__, "an object entered the jump pad");
-
             AZ::Entity* collidingEntity = nullptr;
             AZ::EntityId collidingEntityId = triggerEvent.m_otherBody->GetEntityId();
             AZ::ComponentApplicationBus::BroadcastResult(collidingEntity,

--- a/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/JumpPadComponent.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Source/AutoGen/JumpPadComponent.AutoComponent.h>
+
+namespace MultiplayerSample
+{
+    class JumpPadComponent
+        : public JumpPadComponentBase
+    {
+    public:
+        AZ_MULTIPLAYER_COMPONENT(MultiplayerSample::JumpPadComponent, s_jumpPadComponentConcreteUuid, MultiplayerSample::JumpPadComponentBase);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        void OnInit() override;
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+    };
+
+
+    class JumpPadComponentController
+        : public JumpPadComponentControllerBase
+    {
+    public:
+        explicit JumpPadComponentController(JumpPadComponent& parent);
+
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+    private:
+        void OnTriggerEnter(AzPhysics::SimulatedBodyHandle bodyHandle, const AzPhysics::TriggerEvent& triggerEvent);
+        AzPhysics::SimulatedBodyEvents::OnTriggerEnter::Handler m_enterTrigger{ [this](
+            AzPhysics::SimulatedBodyHandle bodyHandle, const AzPhysics::TriggerEvent& triggerEvent)
+        {
+            OnTriggerEnter(bodyHandle, triggerEvent);
+        } };
+    };
+}

--- a/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Multiplayer/Components/NetworkCharacterComponent.h>
+#include <Multiplayer/Components/NetworkTransformComponent.h>
+#include <Source/Components/Multiplayer/PlayerJumpPadEffectComponent.h>
+
+namespace MultiplayerSample
+{
+    void PlayerJumpPadEffectComponent::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<PlayerJumpPadEffectComponent, PlayerJumpPadEffectComponentBase>()
+                ->Version(1);
+        }
+        PlayerJumpPadEffectComponentBase::Reflect(context);
+    }
+
+    void PlayerJumpPadEffectComponent::OnInit()
+    {
+    }
+
+    void PlayerJumpPadEffectComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void PlayerJumpPadEffectComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+
+    PlayerJumpPadEffectComponentController::PlayerJumpPadEffectComponentController(PlayerJumpPadEffectComponent& parent)
+        : PlayerJumpPadEffectComponentControllerBase(parent)
+    {
+    }
+
+    void PlayerJumpPadEffectComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+    }
+
+    void PlayerJumpPadEffectComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        m_jumpPadEffectEvent.RemoveFromQueue();
+    }
+
+    void PlayerJumpPadEffectComponentController::HandleRPC_ApplyJumpPadEffect(
+        [[maybe_unused]] AzNetworking::IConnection* invokingConnection, 
+        const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration)
+    {
+        AZ_Printf(__FUNCTION__, "");
+
+        GetNetworkTransformComponentController()->ModifyResetCount()++;
+        RPC_StartJump(jumpVelocity, effectDuration);
+    }
+
+    void PlayerJumpPadEffectComponentController::HandleRPC_StartJump([[maybe_unused]] AzNetworking::IConnection* invokingConnection,
+        const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration)
+    {
+        AZ_Printf(__FUNCTION__, "");
+
+        m_isUnderJumpPadEffect = true;
+        m_jumpPadVector = jumpVelocity;
+        m_jumpPadEffectEvent.Enqueue(effectDuration);
+    }
+
+    void PlayerJumpPadEffectComponentController::JumpPadEffectTick()
+    {
+        AZ_Printf(__FUNCTION__, "Jump effect is over");
+
+        // Jump effect is over
+        m_isUnderJumpPadEffect = false;
+    }
+
+    void PlayerJumpPadEffectComponentController::CreateInput([[maybe_unused]] Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
+    {
+        auto* componentInput = input.FindComponentInput<PlayerJumpPadEffectComponentNetworkInput>();
+        if (componentInput)
+        {
+            componentInput->m_jumpPadEffect = m_isUnderJumpPadEffect;
+            componentInput->m_jumpPadVector = m_jumpPadVector;
+        }
+    }
+
+    void PlayerJumpPadEffectComponentController::ProcessInput([[maybe_unused]] Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
+    {
+        const auto* componentInput = input.FindComponentInput<PlayerJumpPadEffectComponentNetworkInput>();
+        if (componentInput)
+        {
+            if (componentInput->m_jumpPadEffect)
+            {
+                GetNetworkCharacterComponentController()->TryMoveWithVelocity(componentInput->m_jumpPadVector, deltaTime);
+            }
+            else // apply gravity
+            {                
+                const AZ::Vector3 gravity = AZ::Vector3::CreateAxisZ(-GetGravity());
+                GetNetworkCharacterComponentController()->TryMoveWithVelocity(gravity, deltaTime);
+            }
+        }
+    }
+}

--- a/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.cpp
@@ -53,8 +53,6 @@ namespace MultiplayerSample
         [[maybe_unused]] AzNetworking::IConnection* invokingConnection, 
         const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration)
     {
-        AZ_Printf(__FUNCTION__, "");
-
         GetNetworkTransformComponentController()->ModifyResetCount()++;
         RPC_StartJump(jumpVelocity, effectDuration);
     }
@@ -62,8 +60,6 @@ namespace MultiplayerSample
     void PlayerJumpPadEffectComponentController::HandleRPC_StartJump([[maybe_unused]] AzNetworking::IConnection* invokingConnection,
         const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration)
     {
-        AZ_Printf(__FUNCTION__, "");
-
         m_isUnderJumpPadEffect = true;
         m_jumpPadVector = jumpVelocity;
         m_jumpPadEffectEvent.Enqueue(effectDuration);
@@ -71,8 +67,6 @@ namespace MultiplayerSample
 
     void PlayerJumpPadEffectComponentController::JumpPadEffectTick()
     {
-        AZ_Printf(__FUNCTION__, "Jump effect is over");
-
         // Jump effect is over
         m_isUnderJumpPadEffect = false;
     }

--- a/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerJumpPadEffectComponent.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Source/AutoGen/PlayerJumpPadEffectComponent.AutoComponent.h>
+
+namespace MultiplayerSample
+{
+    class PlayerJumpPadEffectComponent
+        : public PlayerJumpPadEffectComponentBase
+    {
+    public:
+        AZ_MULTIPLAYER_COMPONENT(MultiplayerSample::PlayerJumpPadEffectComponent, s_playerJumpPadEffectComponentConcreteUuid, MultiplayerSample::PlayerJumpPadEffectComponentBase);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void OnInit() override;
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+    };
+
+
+    class PlayerJumpPadEffectComponentController
+        : public PlayerJumpPadEffectComponentControllerBase
+    {
+    public:
+        explicit PlayerJumpPadEffectComponentController(PlayerJumpPadEffectComponent& parent);
+
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+        //! Common input creation logic for the NetworkInput.
+        //! Fill out the input struct and the MultiplayerInputDriver will send the input data over the network
+        //!    to ensure it's processed.
+        //! @param input  input structure which to store input data for sending to the authority
+        //! @param deltaTime amount of time to integrate the provided inputs over
+        void CreateInput(Multiplayer::NetworkInput& input, float deltaTime) override;
+
+        //! Common input processing logic for the NetworkInput.
+        //! @param input  input structure to process
+        //! @param deltaTime amount of time to integrate the provided inputs over
+        void ProcessInput(Multiplayer::NetworkInput& input, float deltaTime) override;
+
+        void HandleRPC_ApplyJumpPadEffect(AzNetworking::IConnection* invokingConnection, const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration) override;
+        void HandleRPC_StartJump(AzNetworking::IConnection* invokingConnection, const AZ::Vector3& jumpVelocity, const AZ::TimeMs& effectDuration) override;
+
+    private:
+        bool m_isUnderJumpPadEffect = false;
+        AZ::Vector3 m_jumpPadVector = AZ::Vector3::CreateZero();
+        
+        void JumpPadEffectTick();
+        AZ::ScheduledEvent m_jumpPadEffectEvent{ [this]()
+        {
+            JumpPadEffectTick();
+        }, AZ::Name("PlayerJumpPadEffect") };
+    };
+}

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -136,4 +136,12 @@ set(FILES
     Source/MultiplayerSampleSystemComponent.cpp
     Source/MultiplayerSampleSystemComponent.h
     Source/MultiplayerSampleTypes.h
+
+    # Jump Pad logic
+    Source/AutoGen/JumpPadComponent.AutoComponent.xml
+    Source/Components/Multiplayer/JumpPadComponent.cpp
+    Source/Components/Multiplayer/JumpPadComponent.h
+    Source/AutoGen/PlayerJumpPadEffectComponent.AutoComponent.xml
+    Source/Components/Multiplayer/PlayerJumpPadEffectComponent.cpp
+    Source/Components/Multiplayer/PlayerJumpPadEffectComponent.h
 )

--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -75,7 +75,8 @@
                     "Entity_[727777302952]",
                     "Entity_[38397922475797]",
                     "Entity_[3691264858177]",
-                    "Entity_[859737656967]"
+                    "Entity_[859737656967]",
+                    "Instance_[3994533773825]/ContainerEntity"
                 ]
             }
         }
@@ -6359,6 +6360,71 @@
                 }
             ]
         },
+        "Instance_[23584991524674]": {
+            "Source": "Prefabs/Jump_Pad.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Parent Entity",
+                    "value": "../Entity_[356758116574]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/0",
+                    "value": 27.576793670654297
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/1",
+                    "value": -6.407594680786133
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/2",
+                    "value": 0.011153697967529297
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Rotate/2",
+                    "value": 64.4781265258789
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetId/guid",
+                    "value": "{52764BA3-1AC0-591B-955D-829083A5DE8F}"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetId/subId",
+                    "value": 2518358450
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "objects/jump_pad.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetId/guid",
+                    "value": "{52764BA3-1AC0-591B-955D-829083A5DE8F}"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetId/subId",
+                    "value": 2518358450
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "objects/jump_pad.pxmesh"
+                }
+            ]
+        },
         "Instance_[3293577808227]": {
             "Source": "Prefabs/4x4x4BoxGrid.prefab",
             "Patches": [
@@ -6820,6 +6886,71 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16896350622714100755]/Transform Data/Rotate/2",
                     "value": -87.5962142944336
+                }
+            ]
+        },
+        "Instance_[3994533773825]": {
+            "Source": "Prefabs/Jump_Pad.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Parent Entity",
+                    "value": "../Entity_[356758116574]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/0",
+                    "value": 6.4868574142456055
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/1",
+                    "value": 5.3447675704956055
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Translate/2",
+                    "value": 0.011153697967529297
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[4868483987734638563]/Transform Data/Rotate/2",
+                    "value": -128.8099365234375
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetId/guid",
+                    "value": "{52764BA3-1AC0-591B-955D-829083A5DE8F}"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetId/subId",
+                    "value": 2518358450
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "objects/jump_pad.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetId/guid",
+                    "value": "{52764BA3-1AC0-591B-955D-829083A5DE8F}"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetId/subId",
+                    "value": 2518358450
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/loadBehavior",
+                    "value": "QueueLoad"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[879474645241]/Components/Component_[1320441123159991856]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "objects/jump_pad.pxmesh"
                 }
             ]
         },

--- a/Objects/jump_pad.blend
+++ b/Objects/jump_pad.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f5af797a1be67156fc8170edb1b50d846ba98c7fa162d2c5f065a6020b6bf57
+size 836484

--- a/Objects/jump_pad.fbx
+++ b/Objects/jump_pad.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c35b694c1085a3fa2224d02e2930a1be9d00e49936c8059f5d146ecef5b0e9ff
+size 12252

--- a/Objects/jump_pad.fbx.assetinfo
+++ b/Objects/jump_pad.fbx.assetinfo
@@ -1,0 +1,44 @@
+{
+    "values": [
+        {
+            "$type": "{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B} MeshGroup",
+            "id": "{AFF57A0A-9227-559A-A5A8-445F601A8FF9}",
+            "name": "jump_pad",
+            "NodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode.Cube"
+                ],
+                "unselectedNodes": [
+                    {},
+                    "RootNode"
+                ]
+            },
+            "PhysicsMaterialSlots": {
+                "Slots": [
+                    {
+                        "Name": "DefaultMaterial"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "jump_pad",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    {},
+                    "RootNode",
+                    "RootNode.Cube"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{6388520A-DE07-54DD-8426-43C44D833548}"
+        }
+    ]
+}

--- a/Prefabs/Jump_Pad.prefab
+++ b/Prefabs/Jump_Pad.prefab
@@ -1,0 +1,362 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Jump_Pad",
+        "Components": {
+            "Component_[11833957032818997592]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 11833957032818997592
+            },
+            "Component_[17116118936771923623]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 17116118936771923623,
+                "Child Entity Order": [
+                    "Entity_[870884710649]"
+                ]
+            },
+            "Component_[17647569774325953738]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 17647569774325953738
+            },
+            "Component_[2068698522114244344]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 2068698522114244344
+            },
+            "Component_[4868483987734638563]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4868483987734638563,
+                "Parent Entity": ""
+            },
+            "Component_[526277165904729370]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 526277165904729370
+            },
+            "Component_[6247048423506022872]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 6247048423506022872
+            },
+            "Component_[7988753762402592505]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 7988753762402592505
+            },
+            "Component_[8275605844140950722]": {
+                "$type": "EditorLockComponent",
+                "Id": 8275605844140950722
+            },
+            "Component_[9493663043979608841]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9493663043979608841
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[870884710649]": {
+            "Id": "Entity_[870884710649]",
+            "Name": "Jump Pad",
+            "Components": {
+                "Component_[1185715270156812311]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1185715270156812311
+                },
+                "Component_[12430382301978975471]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12430382301978975471
+                },
+                "Component_[1530632711029639956]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1530632711029639956
+                },
+                "Component_[16493884633296455256]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16493884633296455256,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[16688270418198364454]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16688270418198364454
+                },
+                "Component_[17162729604377223959]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17162729604377223959,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            0.000013660377589985728
+                        ]
+                    }
+                },
+                "Component_[17792969157736167259]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17792969157736167259
+                },
+                "Component_[1935099591485995531]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1935099591485995531
+                },
+                "Component_[2661609229233795858]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2661609229233795858,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[7135331581762179843]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7135331581762179843,
+                    "Child Entity Order": [
+                        "Entity_[879474645241]",
+                        "Entity_[875179677945]"
+                    ]
+                },
+                "Component_[9127719548496298131]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9127719548496298131,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17162729604377223959
+                        },
+                        {
+                            "ComponentId": 2661609229233795858,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16493884633296455256,
+                            "SortIndex": 2
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[875179677945]": {
+            "Id": "Entity_[875179677945]",
+            "Name": "Jump Pad Detector",
+            "Components": {
+                "Component_[10089533960369615228]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10089533960369615228,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[10706272707982132991]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10706272707982132991,
+                    "m_template": {
+                        "$type": "MultiplayerSample::JumpPadComponent",
+                        "JumpVelocity": 10.0,
+                        "JumpDuration": 2000
+                    }
+                },
+                "Component_[11364862236658131028]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11364862236658131028
+                },
+                "Component_[11645429160233386144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11645429160233386144
+                },
+                "Component_[13329144701653463968]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13329144701653463968
+                },
+                "Component_[15609335144954614819]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15609335144954614819
+                },
+                "Component_[3876374069328502786]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3876374069328502786
+                },
+                "Component_[5288111746761987569]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5288111746761987569
+                },
+                "Component_[5459222238996576739]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5459222238996576739,
+                    "Parent Entity": "Entity_[870884710649]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.26211118698120117,
+                            0.2405543327331543,
+                            1.1113882064819336
+                        ],
+                        "Rotate": [
+                            16.99999237060547,
+                            0.0,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[6022230047961309769]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 6022230047961309769,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "Position": [
+                            -0.2587048411369324,
+                            -0.01622152328491211,
+                            -0.4519158601760864
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                1.5,
+                                1.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[7916417083735857593]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7916417083735857593
+                },
+                "Component_[81125327900736471]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 81125327900736471
+                },
+                "Component_[9279311253010100805]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 9279311253010100805,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[9746619867899900279]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9746619867899900279,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true
+                    }
+                }
+            }
+        },
+        "Entity_[879474645241]": {
+            "Id": "Entity_[879474645241]",
+            "Name": "Jump Pad Mesh",
+            "Components": {
+                "Component_[10381252435048010465]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381252435048010465
+                },
+                "Component_[10646139244025081355]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10646139244025081355
+                },
+                "Component_[12460276550154915338]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12460276550154915338
+                },
+                "Component_[1320441123159991856]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1320441123159991856,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[13784909050924720005]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13784909050924720005
+                },
+                "Component_[14554559564136193069]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 14554559564136193069,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[15868438811917829257]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 15868438811917829257,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": {
+                                "{}": {
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{F4DF12BC-C818-550C-AA95-F4BE4A457772}"
+                                        },
+                                        "assetHint": "materials/presets/macbeth/14_green_tex.azmaterial"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[17260698852462033441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17260698852462033441,
+                    "Parent Entity": "Entity_[870884710649]",
+                    "Transform Data": {
+                        "Rotate": [
+                            0.0,
+                            0.0,
+                            90.0
+                        ]
+                    }
+                },
+                "Component_[3665156267608823222]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3665156267608823222
+                },
+                "Component_[3789725651375458732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3789725651375458732
+                },
+                "Component_[4633469308968465590]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4633469308968465590
+                },
+                "Component_[4679835474277264560]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4679835474277264560
+                },
+                "Component_[6397980532267620841]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 6397980532267620841,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[6960278601092938443]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 6960278601092938443,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{52764BA3-1AC0-591B-955D-829083A5DE8F}",
+                                    "subId": 273148126
+                                },
+                                "assetHint": "objects/jump_pad.azmodel"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -51,6 +51,14 @@
             "Id": "Entity_[1423682492746]",
             "Name": "Player",
             "Components": {
+                "Component_[1023453620337530999]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1023453620337530999,
+                    "m_template": {
+                        "$type": "MultiplayerSample::PlayerJumpPadEffectComponent",
+                        "Gravity": 5.0
+                    }
+                },
                 "Component_[10731928891422556040]": {
                     "$type": "GenericComponentWrapper",
                     "Id": 10731928891422556040,


### PR DESCRIPTION
- 2 new components: Jump Pad Component and Player Jump Pad Effect Component
- Jump Pad notifies Player Jump Pad Effect of the effect
- Player Jump Pad Effect sends from Authority to Autonomous to mimic a player input
- The jump pad effect is played on both the client and the server to avoid local prediction misses (not perfect yet, though - I think there is a mis predict at the end of the motion)
- Added a placeholder model for the jump pad
- Player Jump Pad Effect Component handles gravity when a jump pad effect isn't on

![image](https://user-images.githubusercontent.com/5432499/191142149-9e48ce9e-1b61-4251-a4a5-08a3d500d9f4.png)

