### PR TITLE
Expose Bot mode as client side option

### DIFF
--- a/Gem/Code/Source/Components/NetworkAiComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAiComponent.cpp
@@ -16,6 +16,9 @@
 
 namespace MultiplayerSample
 {
+    // Cvar: mps_npcMode
+    AZ_CVAR(bool, mps_npcMode, false, nullptr, AZ::ConsoleFunctorFlags::Null, "If true enable NPC mode for MultiplayerSample.");
+
     constexpr static float SecondsToMs = 1000.f;
 
     NetworkAiComponentController::NetworkAiComponentController(NetworkAiComponent& parent)
@@ -25,6 +28,11 @@ namespace MultiplayerSample
 
     void NetworkAiComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        if (IsNetEntityRoleAutonomous() && mps_npcMode)
+        {
+            SetEnabled(true);
+        }
+
         if (GetEnabled())
         {
             Multiplayer::LocalPredictionPlayerInputComponentController* playerInputController = GetLocalPredictionPlayerInputComponentController();

--- a/Gem/Code/Source/Components/NetworkAiComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAiComponent.cpp
@@ -16,7 +16,6 @@
 
 namespace MultiplayerSample
 {
-    // Cvar: mps_botMode
     AZ_CVAR(bool, mps_botMode, false, nullptr, AZ::ConsoleFunctorFlags::Null, "If true, enable bot (AI) mode for client.");
 
     constexpr static float SecondsToMs = 1000.f;

--- a/Gem/Code/Source/Components/NetworkAiComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAiComponent.cpp
@@ -16,8 +16,8 @@
 
 namespace MultiplayerSample
 {
-    // Cvar: mps_npcMode
-    AZ_CVAR(bool, mps_npcMode, false, nullptr, AZ::ConsoleFunctorFlags::Null, "If true enable NPC mode for MultiplayerSample.");
+    // Cvar: mps_botMode
+    AZ_CVAR(bool, mps_botMode, false, nullptr, AZ::ConsoleFunctorFlags::Null, "If true, enable bot (AI) mode for client.");
 
     constexpr static float SecondsToMs = 1000.f;
 
@@ -28,7 +28,7 @@ namespace MultiplayerSample
 
     void NetworkAiComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        if (IsNetEntityRoleAutonomous() && mps_npcMode)
+        if (IsNetEntityRoleAutonomous() && mps_botMode)
         {
             SetEnabled(true);
         }
@@ -145,7 +145,7 @@ namespace MultiplayerSample
     }
 
     void NetworkAiComponentController::ConfigureAi(
-            float fireIntervalMinMs, float fireIntervalMaxMs, float actionIntervalMinMs, float actionIntervalMaxMs, uint64_t seed)
+        float fireIntervalMinMs, float fireIntervalMaxMs, float actionIntervalMinMs, float actionIntervalMaxMs, uint64_t seed)
     {
         SetFireIntervalMinMs(fireIntervalMinMs);
         SetFireIntervalMaxMs(fireIntervalMaxMs);

--- a/Gem/Code/Source/Components/NetworkAiComponent.h
+++ b/Gem/Code/Source/Components/NetworkAiComponent.h
@@ -32,7 +32,6 @@ namespace MultiplayerSample
 
     private:
         friend class NetworkStressTestComponentController;
-        friend class MultiplayerSampleSystemComponent;
 
         void ConfigureAi(
             float fireIntervalMinMs, float fireIntervalMaxMs, float actionIntervalMinMs, float actionIntervalMaxMs, uint64_t seed);

--- a/Gem/Code/Source/Components/NetworkAiComponent.h
+++ b/Gem/Code/Source/Components/NetworkAiComponent.h
@@ -16,8 +16,8 @@ namespace MultiplayerSample
     class NetworkWeaponsComponentController;
     class NetworkPlayerMovementComponentController;
 
-    // The NetworkAiComponent, when active, can execute behaviors and produce synthetic inputs to drive the
-    // NetworkPlayerMovementComponentController and NetworkWeaponsComponentController.
+    //! The NetworkAiComponent, when active, can execute behaviors and produce synthetic inputs to drive the
+    //! NetworkPlayerMovementComponentController and NetworkWeaponsComponentController.
     class NetworkAiComponentController
         : public NetworkAiComponentControllerBase
     {

--- a/Gem/Code/Source/Components/NetworkAiComponent.h
+++ b/Gem/Code/Source/Components/NetworkAiComponent.h
@@ -32,7 +32,6 @@ namespace MultiplayerSample
 
     private:
         friend class NetworkStressTestComponentController;
-
         void ConfigureAi(
             float fireIntervalMinMs, float fireIntervalMaxMs, float actionIntervalMinMs, float actionIntervalMaxMs, uint64_t seed);
 

--- a/Gem/Code/Source/Components/NetworkAiComponent.h
+++ b/Gem/Code/Source/Components/NetworkAiComponent.h
@@ -32,6 +32,8 @@ namespace MultiplayerSample
 
     private:
         friend class NetworkStressTestComponentController;
+        friend class MultiplayerSampleSystemComponent;
+
         void ConfigureAi(
             float fireIntervalMinMs, float fireIntervalMaxMs, float actionIntervalMinMs, float actionIntervalMaxMs, uint64_t seed);
 

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -119,7 +119,7 @@ namespace MultiplayerSample
 
         Multiplayer::INetworkEntityManager::EntityList entityList =
             AZ::Interface<Multiplayer::IMultiplayer>::Get()->GetNetworkEntityManager()->CreateEntitiesImmediate(
-                entityParams.first, Multiplayer::NetEntityRole::Authority, entityParams.second, Multiplayer::AutoActivate::DoNotActivate);
+            entityParams.first, Multiplayer::NetEntityRole::Authority, entityParams.second, Multiplayer::AutoActivate::DoNotActivate);
 
         for (Multiplayer::NetworkEntityHandle subEntity : entityList)
         {

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -8,7 +8,6 @@
 #include "MultiplayerSampleSystemComponent.h"
 
 #include <AzCore/Console/ILogger.h>
-#include <AzCore/Console/IConsole.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
@@ -23,14 +22,10 @@
 #include <Multiplayer/Components/NetBindComponent.h>
 #include <Multiplayer/ConnectionData/IConnectionData.h>
 #include <Multiplayer/ReplicationWindows/IReplicationWindow.h>
-#include <Source/Components/NetworkAiComponent.h>
 
 namespace MultiplayerSample
 {
     using namespace AzNetworking;
-
-    // CVar: cl_npcMode
-    AZ_CVAR(bool, mps_npcMode, false, nullptr, AZ::ConsoleFunctorFlags::Null, "If true enable NPC mode for MultiplayerSample.");
 
     void MultiplayerSampleSystemComponent::Reflect(AZ::ReflectContext* context)
     {
@@ -142,16 +137,6 @@ namespace MultiplayerSample
                 entityParams.first.m_prefabName.GetCStr());
         }
 
-        // See if we make client NPC
-        if (mps_npcMode)
-        {
-            uint64_t seed = static_cast<uint64_t>(AZ::Interface<AZ::ITime>::Get()->GetElapsedTimeMs()) + static_cast<uint64_t>(controlledEntity.GetNetEntityId());
-
-            NetworkAiComponentController* networkAiController = controlledEntity.FindController<NetworkAiComponentController>();
-            // Best guess options to create activity for NPC clients
-            networkAiController->ConfigureAi(1000, 10000, 150, 1000, seed);
-            networkAiController->SetEnabled(true);
-        }
         return controlledEntity;
     }
 


### PR DESCRIPTION
Allow clients to be launched with `--mps_botMode=true` to activate the ai controller to autoplay for the client.

This is an important mode for load testing  (ie 2 local players + 50 bots).

Could target to base MPS as well as that functionality is there.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>