### PR TITLE
Add safety guards to bot mode

### DIFF
--- a/Gem/Code/Source/Components/NetworkAiComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAiComponent.cpp
@@ -23,19 +23,18 @@ namespace MultiplayerSample
     NetworkAiComponentController::NetworkAiComponentController(NetworkAiComponent& parent)
         : NetworkAiComponentControllerBase(parent)
     {
-    }
-
-    void NetworkAiComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
-    {
-        if (IsNetEntityRoleAutonomous() && mps_botMode)
+    	if (IsNetEntityRoleAutonomous() && mps_botMode)
         {
             SetEnabled(true);
         }
+	}
 
+    void NetworkAiComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
         if (GetEnabled())
         {
             Multiplayer::LocalPredictionPlayerInputComponentController* playerInputController = GetLocalPredictionPlayerInputComponentController();
-            if (playerInputController != nullptr)
+            if (playerInputController != nullptr && !IsNetEntityRoleAutonomous())
             {
                 playerInputController->ForceEnableAutonomousUpdate();
             }
@@ -47,7 +46,7 @@ namespace MultiplayerSample
         if (GetEnabled())
         {
             Multiplayer::LocalPredictionPlayerInputComponentController* playerInputController = GetLocalPredictionPlayerInputComponentController();
-            if (playerInputController != nullptr)
+            if (playerInputController != nullptr && !IsNetEntityRoleAutonomous())
             {
                 playerInputController->ForceDisableAutonomousUpdate();
             }


### PR DESCRIPTION
As discussed in and offline, adds guards to bot mode

## Tested
* Tested going in and out of game with bot mode on/off - see expected behaviour
* Tested on server with rendering, spawning ai entity via ImGui test mode.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>