### PR TITLE
Updated PopcornFX project assets to 2.14

### DIFF
--- a/PopcornFX/Editor/AnimationTracks/Circle.pkcf
+++ b/PopcornFX/Editor/AnimationTracks/Circle.pkcf
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 COvenBakeConfig_Mesh	$82362157
 {
 	ImportGeometry = false;

--- a/PopcornFX/Editor/AnimationTracks/PingPong.pkcf
+++ b/PopcornFX/Editor/AnimationTracks/PingPong.pkcf
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 COvenBakeConfig_Mesh	$A6D04D13
 {
 	ImportGeometry = false;

--- a/PopcornFX/Editor/Presets/Effects/Basic.pkfx
+++ b/PopcornFX/Editor/Presets/Effects/Basic.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:261ee339f0f358388e665504ce6401f4d4f9678772b0367be8edc87bec0ea275
-size 28879
+oid sha256:b8baf2357a2dfc224702f0b3ebb2b9d9fe4957cb1f0806cf6cd09278d7ce2abf
+size 28990

--- a/PopcornFX/Editor/Presets/Effects/FX_Simple.pkfx
+++ b/PopcornFX/Editor/Presets/Effects/FX_Simple.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bca9bfb422dd30b26e1aab18e00505bd280ab777685f07e2f5357cc46f73196a
-size 30202
+oid sha256:dfb98368c7b254b03fb53a3fabfd68032a09ce824a6e82498eb1a1bc9b0085c0
+size 30313

--- a/PopcornFX/Library/PopcornFXCore/Materials/Animated_Mesh.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Animated_Mesh.pkma
@@ -5,18 +5,22 @@ CParticleRendererFeatureSet	$6B70D015
 		"$A8FC2215",
 		"$18565271",
 		"$8F7B32AE",
-		"$9154DFA0",
 		"$35A36C4E",
+		"$48A1612A",
+		"$889B8BF4",
+		"$E0B8480E",
+		"$9B409ABD",
+		"$9154DFA0",
 		"$8BF32864",
 		"$ECD07C82",
-		"$1C9B3978",
+		"$B408CF5C",
 		"$D857A09F",
 		"$4B933A29",
 		"$4B954A29",
 		"$EAC726E3",
 		"$3BE1856D",
 		"$1A35A1FF",
-		"$D72B521A",
+		"$F22CBF26",
 	};
 }
 CParticleRendererFeatureDesc	$A8FC2215
@@ -80,6 +84,7 @@ CParticleRendererFeatureDesc	$EAC726E3
 }
 CRHIMaterialShaders	$00269EC3
 {
+	VertexShader = "Library/PopcornFXCore/Shaders/AnimatedMesh.vert";
 	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Mesh.frag";
 }
 CParticleRendererFeatureDesc	$3BE1856D
@@ -92,13 +97,34 @@ CParticleRendererFeatureDesc	$1A35A1FF
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
 	RendererFeatureName = "UseVertexColors";
 }
-CParticleRendererFeatureDesc	$D72B521A
+CParticleRendererFeatureDesc	$48A1612A
 {
-	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
-	RendererFeatureName = "MeshLOD";
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri";
+	RendererFeatureName = "SkeletalAnimation";
+	Mandatory = true;
 }
-CParticleRendererFeatureDesc	$1C9B3978
+CParticleRendererFeatureDesc	$E0B8480E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri";
+	RendererFeatureName = "SkeletalAnimationInterpolate";
+}
+CParticleRendererFeatureDesc	$9B409ABD
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri";
+	RendererFeatureName = "SkeletalAnimationInterpolateTracks";
+}
+CParticleRendererFeatureDesc	$889B8BF4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri";
+	RendererFeatureName = "SkeletalAnimationUseBonesScale";
+}
+CParticleRendererFeatureDesc	$B408CF5C
 {
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
 	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$F22CBF26
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "MeshLOD";
 }

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Billboard.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Decal.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Decal.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Light.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Light.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Ribbon.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Sound.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Sound.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Triangle.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Triangle.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Billboard.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Ribbon.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Diffuse.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Distortion.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Opaque.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Tinted.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Diffuse.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Light/Light_Default.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Light/Light_Default.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {
@@ -7,6 +7,7 @@ CParticleRendererFeatureSet	$6B70D015
 		"$93540081",
 		"$35A36C4E",
 		"$7FB4AB5F",
+		"$337C6546",
 		"$1DB717AE",
 		"$EAC726E3",
 		"$1BCA2B7D",
@@ -77,4 +78,9 @@ CParticleRendererFeatureDesc	$98B9ED49
 {
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
 	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$337C6546
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
 }

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Opaque.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {
@@ -10,6 +10,7 @@ CParticleRendererFeatureSet	$6B70D015
 		"$EA3837ED",
 		"$35A36C4E",
 		"$7FB4AB5F",
+		"$CB4D3C7E",
 		"$1098ED35",
 		"$1DB717AE",
 		"$EAC726E3",
@@ -95,4 +96,9 @@ CParticleRendererFeatureDesc	$862F644E
 {
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
 	RendererFeatureName = "UseVertexColors";
+}
+CParticleRendererFeatureDesc	$CB4D3C7E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
 }

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Tinted.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {
@@ -8,6 +8,7 @@ CParticleRendererFeatureSet	$6B70D015
 		"$B9161D10",
 		"$35A36C4E",
 		"$7FB4AB5F",
+		"$0A9DCEA3",
 		"$1DB717AE",
 		"$EAC726E3",
 		"$1BCA2B7D",
@@ -89,4 +90,9 @@ CParticleRendererFeatureDesc	$B9161D10
 {
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
 	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$0A9DCEA3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
 }

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Diffuse.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Distortion.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Opaque.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Tinted.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Diffuse.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Distortion.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Opaque.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Tinted.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Sound/Sound_Default.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Sound/Sound_Default.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Diffuse.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Distortion.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Emissive.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Opaque.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Tinted.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/Editor.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/Editor.pkri
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CEngineRendererInterface	$6B70D015
 {
 	InterfaceName = "Editor features";
@@ -49,6 +49,7 @@ CEngineRendererInterface	$6B70D015
 		"$1BDFA32C",
 		"$5CBB6243",
 		"$71D528E3",
+		"$E75E73C7",
 	};
 }
 CParticleRendererFeature	$81861AB7
@@ -2059,7 +2060,6 @@ CParticleNodeTemplateExport	$43290D5A
 	ExportedName = "LegacyLit.SpecularMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:LegacyLit",
 	};
@@ -2378,7 +2378,6 @@ CParticleNodeTemplateExport	$43290D5D
 	ExportedName = "Lit.RoughMetalMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Lit",
 	};
@@ -2562,6 +2561,7 @@ CRHIRenderingSettings	$6DF50834
 		"$16512360",
 		"$DD26542E",
 		"$A2DFDBD4",
+		"$DBCFAF80",
 	};
 }
 CRHIRenderingFeature	$EA67A6E3
@@ -4764,7 +4764,6 @@ CParticleNodeTemplateExport	$E31D7A62
 	ExportedName = "Lit.LitMaskMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Lit",
 	};
@@ -4829,7 +4828,6 @@ CParticleNodeTemplateExport	$1810889B
 	ExportedName = "Tint.TintMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Tint",
 	};
@@ -4945,4 +4943,68 @@ CRHIRenderingFeature	$A2DFDBD4
 {
 	FeatureName = "UseVertexColors";
 	UseMeshVertexColor0 = true;
+}
+CParticleRendererFeature	$E75E73C7
+{
+	FeatureName = "MeshLOD";
+	Feature = "$D8754C52";
+	Properties = {
+		"$B5B5302A",
+	};
+}
+CParticleNodeTemplateExport	$D8754C52
+{
+	InputPins = {
+		"$B22FDB79",
+	};
+	OutputPins = {
+		"$53975DDA",
+	};
+	ExportedName = "MeshLOD";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$B22FDB79
+{
+	SelfName = "DefaultValue";
+	Owner = "$D8754C52";
+}
+CParticleNodePinOut	$53975DDA
+{
+	SelfName = "Value";
+	Owner = "$D8754C52";
+}
+CRHIRenderingFeature	$DBCFAF80
+{
+	FeatureName = "MeshLOD";
+}
+CParticleNodeTemplateExport	$B5B5302A
+{
+	Description = {
+		"@eng:Index of the level of detail to render",
+	};
+	InputPins = {
+		"$4CC1A594",
+	};
+	OutputPins = {
+		"$87008ABA",
+	};
+	ExportedName = "MeshLOD.LOD";
+	ExportedType = int;
+	Type = Input;
+	CategoryName = {
+		"@eng:MeshLOD",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$4CC1A594
+{
+	SelfName = "DefaultValue";
+	Owner = "$B5B5302A";
+}
+CParticleNodePinOut	$87008ABA
+{
+	SelfName = "Value";
+	Owner = "$B5B5302A";
 }

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/Experimental.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/Experimental.pkri
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CEngineRendererInterface	$6B70D015
 {
 	InterfaceName = "Experimental material features";
@@ -1843,7 +1843,6 @@ CParticleNodeTemplateExport	$43290D5D
 	ExportedName = "Lit.RoughMetalMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Lit",
 	};
@@ -4014,7 +4013,6 @@ CParticleNodeTemplateExport	$E31D7A62
 	ExportedName = "Lit.LitMaskMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Lit",
 	};
@@ -4079,7 +4077,6 @@ CParticleNodeTemplateExport	$1810889B
 	ExportedName = "Tint.TintMap";
 	ExportedType = dataImage;
 	Type = Input;
-	InputType = Property;
 	CategoryName = {
 		"@eng:Tint",
 	};

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/MeshAnim.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/MeshAnim.pkri
@@ -1,0 +1,392 @@
+Version = 2.14.0.14607;
+CEngineRendererInterface	$6B70D015
+{
+	InterfaceName = "Mesh Anim";
+	RendererFeatures = {
+		"$07502AB6",
+		"$85A52676",
+		"$657972C1",
+		"$B4745F99",
+	};
+}
+CRHIRenderingSettings	$6DF50834
+{
+	RenderingFeatures = {
+		"$691E0A5C",
+		"$FBB54BD2",
+		"$F560428A",
+		"$21F97218",
+	};
+}
+CParticleRendererFeature	$07502AB6
+{
+	FeatureName = "SkeletalAnimation";
+	Feature = "$D860242F";
+	Properties = {
+		"$8FED53BE",
+		"$FC06E279",
+		"$811D3FC7",
+		"$4D9DD5F2",
+		"$E0FEB178",
+	};
+}
+CParticleNodeTemplateExport	$D860242F
+{
+	InputPins = {
+		"$F51BABD9",
+	};
+	OutputPins = {
+		"$BA393FB8",
+	};
+	ExportedName = "SkeletalAnimation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$F51BABD9
+{
+	SelfName = "DefaultValue";
+	Owner = "$D860242F";
+}
+CParticleNodePinOut	$BA393FB8
+{
+	SelfName = "Value";
+	Owner = "$D860242F";
+}
+CRHIRenderingFeature	$691E0A5C
+{
+	FeatureName = "SkeletalAnimation";
+	UseMeshVertexBonesIndicesAndWeights = true;
+	PropertiesAsShaderConstants = {
+		"AnimTextureResolution",
+		"AnimationTexture",
+		"AnimTracksCount",
+	};
+	TexturesUsedAsLookUp = {
+		"AnimationTexture",
+	};
+}
+CParticleNodeTemplateExport	$8FED53BE
+{
+	InputPins = {
+		"$51F00EE5",
+	};
+	OutputPins = {
+		"$B8E044B6",
+	};
+	ExportedName = "SkeletalAnimation.AnimationTexture";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+}
+CParticleNodePinIn	$51F00EE5
+{
+	SelfName = "DefaultValue";
+	Owner = "$8FED53BE";
+}
+CParticleNodePinOut	$B8E044B6
+{
+	SelfName = "Value";
+	Owner = "$8FED53BE";
+}
+CParticleNodeTemplateExport	$FC06E279
+{
+	InputPins = {
+		"$70FB0232",
+	};
+	OutputPins = {
+		"$6AED2119",
+	};
+	ExportedName = "SkeletalAnimation.AnimationCursor";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$70FB0232
+{
+	SelfName = "DefaultValue";
+	Owner = "$FC06E279";
+}
+CParticleNodePinOut	$6AED2119
+{
+	SelfName = "Value";
+	Owner = "$FC06E279";
+}
+CParticleNodeTemplateExport	$811D3FC7
+{
+	InputPins = {
+		"$3B8615E2",
+	};
+	OutputPins = {
+		"$4DA235CB",
+	};
+	ExportedName = "SkeletalAnimation.AnimTextureResolution";
+	ExportedType = int2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	DefaultValueI4 = int4(1024, 32, 0, 0);
+}
+CParticleNodePinIn	$3B8615E2
+{
+	SelfName = "DefaultValue";
+	Owner = "$811D3FC7";
+}
+CParticleNodePinOut	$4DA235CB
+{
+	SelfName = "Value";
+	Owner = "$811D3FC7";
+}
+CParticleRendererFeature	$85A52676
+{
+	FeatureName = "SkeletalAnimationInterpolate";
+	Feature = "$8501FD98";
+}
+CParticleNodeTemplateExport	$8501FD98
+{
+	InputPins = {
+		"$3FFF929C",
+	};
+	OutputPins = {
+		"$81C8B393",
+	};
+	ExportedName = "SkeletalAnimationInterpolate";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3FFF929C
+{
+	SelfName = "DefaultValue";
+	Owner = "$8501FD98";
+}
+CParticleNodePinOut	$81C8B393
+{
+	SelfName = "Value";
+	Owner = "$8501FD98";
+}
+CRHIRenderingFeature	$FBB54BD2
+{
+	FeatureName = "SkeletalAnimationInterpolate";
+}
+CParticleNodeTemplateExport	$4D9DD5F2
+{
+	InputPins = {
+		"$2F228D2D",
+	};
+	OutputPins = {
+		"$EDD49B7E",
+	};
+	ExportedName = "SkeletalAnimation.AnimTracksCount";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+	DefaultValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	DefaultValueI4 = int4(1, 0, 0, 0);
+	MinValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MinValueI4 = int4(1, 0, 0, 0);
+}
+CParticleNodePinIn	$2F228D2D
+{
+	SelfName = "DefaultValue";
+	Owner = "$4D9DD5F2";
+}
+CParticleNodePinOut	$EDD49B7E
+{
+	SelfName = "Value";
+	Owner = "$4D9DD5F2";
+}
+CParticleNodeTemplateExport	$E0FEB178
+{
+	InputPins = {
+		"$D93FEB8E",
+	};
+	OutputPins = {
+		"$0CFC3D9B",
+	};
+	ExportedName = "SkeletalAnimation.CurrentAnimTrack";
+	ExportedType = int;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$D93FEB8E
+{
+	SelfName = "DefaultValue";
+	Owner = "$E0FEB178";
+}
+CParticleNodePinOut	$0CFC3D9B
+{
+	SelfName = "Value";
+	Owner = "$E0FEB178";
+}
+CParticleRendererFeature	$657972C1
+{
+	FeatureName = "SkeletalAnimationInterpolateTracks";
+	Feature = "$E7833CC2";
+	Properties = {
+		"$F0BC969B",
+		"$E8EF58FF",
+		"$FEC61C9C",
+	};
+}
+CParticleNodeTemplateExport	$E7833CC2
+{
+	InputPins = {
+		"$98B1DEC4",
+	};
+	OutputPins = {
+		"$5E2A0AF4",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$98B1DEC4
+{
+	SelfName = "DefaultValue";
+	Owner = "$E7833CC2";
+}
+CParticleNodePinOut	$5E2A0AF4
+{
+	SelfName = "Value";
+	Owner = "$E7833CC2";
+}
+CRHIRenderingFeature	$F560428A
+{
+	FeatureName = "SkeletalAnimationInterpolateTracks";
+}
+CParticleNodeTemplateExport	$F0BC969B
+{
+	InputPins = {
+		"$44AEAB2B",
+	};
+	OutputPins = {
+		"$11E97D9F",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.NextAnimTrack";
+	ExportedType = int;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$44AEAB2B
+{
+	SelfName = "DefaultValue";
+	Owner = "$F0BC969B";
+}
+CParticleNodePinOut	$11E97D9F
+{
+	SelfName = "Value";
+	Owner = "$F0BC969B";
+}
+CParticleNodeTemplateExport	$E8EF58FF
+{
+	InputPins = {
+		"$40B88C2E",
+	};
+	OutputPins = {
+		"$E41A2064",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.TransitionRatio";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$40B88C2E
+{
+	SelfName = "DefaultValue";
+	Owner = "$E8EF58FF";
+}
+CParticleNodePinOut	$E41A2064
+{
+	SelfName = "Value";
+	Owner = "$E8EF58FF";
+}
+CParticleRendererFeature	$B4745F99
+{
+	FeatureName = "SkeletalAnimationUseBonesScale";
+	Feature = "$178648F9";
+}
+CParticleNodeTemplateExport	$178648F9
+{
+	InputPins = {
+		"$E9A438AD",
+	};
+	OutputPins = {
+		"$46ADF64A",
+	};
+	ExportedName = "SkeletalAnimationUseBonesScale";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E9A438AD
+{
+	SelfName = "DefaultValue";
+	Owner = "$178648F9";
+}
+CParticleNodePinOut	$46ADF64A
+{
+	SelfName = "Value";
+	Owner = "$178648F9";
+}
+CRHIRenderingFeature	$21F97218
+{
+	FeatureName = "SkeletalAnimationUseBonesScale";
+}
+CParticleNodeTemplateExport	$FEC61C9C
+{
+	InputPins = {
+		"$FE746319",
+	};
+	OutputPins = {
+		"$6EC7EEC8",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.NextAnimationCursor";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$FE746319
+{
+	SelfName = "DefaultValue";
+	Owner = "$FEC61C9C";
+}
+CParticleNodePinOut	$6EC7EEC8
+{
+	SelfName = "Value";
+	Owner = "$FEC61C9C";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/SkeletalAnimationTexture.pkri
@@ -1,0 +1,545 @@
+Version = 2.14.0.14607;
+CEngineRendererInterface	$6B70D015
+{
+	InterfaceName = "Skeletal Animation Texture";
+	RendererFeatures = {
+		"$07502AB6",
+		"$85A52676",
+		"$657972C1",
+		"$B4745F99",
+	};
+}
+CRHIRenderingSettings	$6DF50834
+{
+	RenderingFeatures = {
+		"$691E0A5C",
+		"$FBB54BD2",
+		"$F560428A",
+		"$21F97218",
+	};
+}
+CParticleRendererFeature	$07502AB6
+{
+	FeatureName = "SkeletalAnimation";
+	Feature = "$D860242F";
+	Properties = {
+		"$8FED53BE",
+		"$FC06E279",
+		"$811D3FC7",
+		"$4D9DD5F2",
+		"$E0FEB178",
+		"$1F6E0193",
+		"$C1F6EC94",
+	};
+}
+CParticleNodeTemplateExport	$D860242F
+{
+	InputPins = {
+		"$F51BABD9",
+	};
+	OutputPins = {
+		"$BA393FB8",
+	};
+	ExportedName = "SkeletalAnimation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$F51BABD9
+{
+	SelfName = "DefaultValue";
+	Owner = "$D860242F";
+}
+CParticleNodePinOut	$BA393FB8
+{
+	SelfName = "Value";
+	Owner = "$D860242F";
+}
+CRHIRenderingFeature	$691E0A5C
+{
+	FeatureName = "SkeletalAnimation";
+	UseMeshVertexBonesIndicesAndWeights = true;
+	PropertiesAsShaderConstants = {
+		"AnimTextureResolution",
+		"AnimationTexture",
+		"AnimTracksCount",
+		"AnimPositionsBoundsMin",
+		"AnimPositionsBoundsMax",
+	};
+	TexturesUsedAsLookUp = {
+		"AnimationTexture",
+	};
+}
+CParticleNodeTemplateExport	$8FED53BE
+{
+	Description = {
+		"@eng:Texture containing the packed animations data",
+	};
+	InputPins = {
+		"$51F00EE5",
+	};
+	OutputPins = {
+		"$B8E044B6",
+	};
+	ExportedName = "SkeletalAnimation.AnimationTexture";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+}
+CParticleNodePinIn	$51F00EE5
+{
+	SelfName = "DefaultValue";
+	Owner = "$8FED53BE";
+}
+CParticleNodePinOut	$B8E044B6
+{
+	SelfName = "Value";
+	Owner = "$8FED53BE";
+}
+CParticleNodeTemplateExport	$FC06E279
+{
+	Description = {
+		"@eng:First animation cursor, value between 0 and 1 that defines at what time the first animation is sampled",
+	};
+	InputPins = {
+		"$70FB0232",
+	};
+	OutputPins = {
+		"$6AED2119",
+	};
+	ExportedName = "SkeletalAnimation.AnimationCursor";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$70FB0232
+{
+	SelfName = "DefaultValue";
+	Owner = "$FC06E279";
+}
+CParticleNodePinOut	$6AED2119
+{
+	SelfName = "Value";
+	Owner = "$FC06E279";
+}
+CParticleNodeTemplateExport	$811D3FC7
+{
+	Description = {
+		"@eng:Animation texture resolution, in pixels",
+	};
+	InputPins = {
+		"$3B8615E2",
+	};
+	OutputPins = {
+		"$4DA235CB",
+	};
+	ExportedName = "SkeletalAnimation.AnimTextureResolution";
+	ExportedType = int2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+	DefaultValueI4 = int4(1024, 32, 0, 0);
+	MinValueI4 = int4(1, 1, 0, 0);
+}
+CParticleNodePinIn	$3B8615E2
+{
+	SelfName = "DefaultValue";
+	Owner = "$811D3FC7";
+}
+CParticleNodePinOut	$4DA235CB
+{
+	SelfName = "Value";
+	Owner = "$811D3FC7";
+}
+CParticleRendererFeature	$85A52676
+{
+	FeatureName = "SkeletalAnimationInterpolate";
+	Feature = "$8501FD98";
+}
+CParticleNodeTemplateExport	$8501FD98
+{
+	InputPins = {
+		"$3FFF929C",
+	};
+	OutputPins = {
+		"$81C8B393",
+	};
+	ExportedName = "SkeletalAnimationInterpolate";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3FFF929C
+{
+	SelfName = "DefaultValue";
+	Owner = "$8501FD98";
+}
+CParticleNodePinOut	$81C8B393
+{
+	SelfName = "Value";
+	Owner = "$8501FD98";
+}
+CRHIRenderingFeature	$FBB54BD2
+{
+	FeatureName = "SkeletalAnimationInterpolate";
+}
+CParticleNodeTemplateExport	$4D9DD5F2
+{
+	Description = {
+		"@eng:Number of animations contained in the texture",
+	};
+	InputPins = {
+		"$2F228D2D",
+	};
+	OutputPins = {
+		"$EDD49B7E",
+	};
+	ExportedName = "SkeletalAnimation.AnimTracksCount";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+	DefaultValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	DefaultValueI4 = int4(1, 0, 0, 0);
+	MinValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MinValueI4 = int4(1, 0, 0, 0);
+}
+CParticleNodePinIn	$2F228D2D
+{
+	SelfName = "DefaultValue";
+	Owner = "$4D9DD5F2";
+}
+CParticleNodePinOut	$EDD49B7E
+{
+	SelfName = "Value";
+	Owner = "$4D9DD5F2";
+}
+CParticleNodeTemplateExport	$E0FEB178
+{
+	Description = {
+		"@eng:First animation index to play",
+	};
+	InputPins = {
+		"$D93FEB8E",
+	};
+	OutputPins = {
+		"$0CFC3D9B",
+	};
+	ExportedName = "SkeletalAnimation.CurrentAnimTrack";
+	ExportedType = int;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$D93FEB8E
+{
+	SelfName = "DefaultValue";
+	Owner = "$E0FEB178";
+}
+CParticleNodePinOut	$0CFC3D9B
+{
+	SelfName = "Value";
+	Owner = "$E0FEB178";
+}
+CParticleRendererFeature	$657972C1
+{
+	FeatureName = "SkeletalAnimationInterpolateTracks";
+	Feature = "$E7833CC2";
+	Properties = {
+		"$F0BC969B",
+		"$E8EF58FF",
+		"$FEC61C9C",
+	};
+}
+CParticleNodeTemplateExport	$E7833CC2
+{
+	InputPins = {
+		"$98B1DEC4",
+	};
+	OutputPins = {
+		"$5E2A0AF4",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$98B1DEC4
+{
+	SelfName = "DefaultValue";
+	Owner = "$E7833CC2";
+}
+CParticleNodePinOut	$5E2A0AF4
+{
+	SelfName = "Value";
+	Owner = "$E7833CC2";
+}
+CRHIRenderingFeature	$F560428A
+{
+	FeatureName = "SkeletalAnimationInterpolateTracks";
+}
+CParticleNodeTemplateExport	$F0BC969B
+{
+	Description = {
+		"@eng:Second animation index to play",
+	};
+	InputPins = {
+		"$44AEAB2B",
+	};
+	OutputPins = {
+		"$11E97D9F",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.NextAnimTrack";
+	ExportedType = int;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$44AEAB2B
+{
+	SelfName = "DefaultValue";
+	Owner = "$F0BC969B";
+}
+CParticleNodePinOut	$11E97D9F
+{
+	SelfName = "Value";
+	Owner = "$F0BC969B";
+}
+CParticleNodeTemplateExport	$E8EF58FF
+{
+	Description = {
+		"@eng:Interpolation ratio between the first and the second animation. If its value is 0, the renderer will play the first animation, if it value is 1, the renderer will play the second animation",
+	};
+	InputPins = {
+		"$40B88C2E",
+	};
+	OutputPins = {
+		"$E41A2064",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.TransitionRatio";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$40B88C2E
+{
+	SelfName = "DefaultValue";
+	Owner = "$E8EF58FF";
+}
+CParticleNodePinOut	$E41A2064
+{
+	SelfName = "Value";
+	Owner = "$E8EF58FF";
+}
+CParticleRendererFeature	$B4745F99
+{
+	FeatureName = "SkeletalAnimationUseBonesScale";
+	Feature = "$178648F9";
+	Properties = {
+		"$A5447DEF",
+		"$117B401A",
+	};
+}
+CParticleNodeTemplateExport	$178648F9
+{
+	InputPins = {
+		"$E9A438AD",
+	};
+	OutputPins = {
+		"$46ADF64A",
+	};
+	ExportedName = "SkeletalAnimationUseBonesScale";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E9A438AD
+{
+	SelfName = "DefaultValue";
+	Owner = "$178648F9";
+}
+CParticleNodePinOut	$46ADF64A
+{
+	SelfName = "Value";
+	Owner = "$178648F9";
+}
+CRHIRenderingFeature	$21F97218
+{
+	FeatureName = "SkeletalAnimationUseBonesScale";
+	PropertiesAsShaderConstants = {
+		"AnimScalesBoundsMax",
+		"AnimScalesBoundsMin",
+	};
+}
+CParticleNodeTemplateExport	$FEC61C9C
+{
+	Description = {
+		"@eng:Second animation cursor, value between 0 and 1 that defines at what time the second animation is sampled",
+	};
+	InputPins = {
+		"$FE746319",
+	};
+	OutputPins = {
+		"$6EC7EEC8",
+	};
+	ExportedName = "SkeletalAnimationInterpolateTracks.NextAnimationCursor";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:SkeletalAnimationInterpolateTracks",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$FE746319
+{
+	SelfName = "DefaultValue";
+	Owner = "$FEC61C9C";
+}
+CParticleNodePinOut	$6EC7EEC8
+{
+	SelfName = "Value";
+	Owner = "$FEC61C9C";
+}
+CParticleNodeTemplateExport	$1F6E0193
+{
+	Description = {
+		"@eng:Minimum position values for the skeletal animations contained in the texture",
+	};
+	InputPins = {
+		"$F56C6B08",
+	};
+	OutputPins = {
+		"$AA2623E7",
+	};
+	ExportedName = "SkeletalAnimation.AnimPositionsBoundsMin";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+}
+CParticleNodePinIn	$F56C6B08
+{
+	SelfName = "DefaultValue";
+	Owner = "$1F6E0193";
+}
+CParticleNodePinOut	$AA2623E7
+{
+	SelfName = "Value";
+	Owner = "$1F6E0193";
+}
+CParticleNodeTemplateExport	$C1F6EC94
+{
+	Description = {
+		"@eng:Maximum position values for the skeletal animations contained in the texture",
+	};
+	InputPins = {
+		"$44F741E9",
+	};
+	OutputPins = {
+		"$DD93EC41",
+	};
+	ExportedName = "SkeletalAnimation.AnimPositionsBoundsMax";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimation",
+	};
+}
+CParticleNodePinIn	$44F741E9
+{
+	SelfName = "DefaultValue";
+	Owner = "$C1F6EC94";
+}
+CParticleNodePinOut	$DD93EC41
+{
+	SelfName = "Value";
+	Owner = "$C1F6EC94";
+}
+CParticleNodeTemplateExport	$A5447DEF
+{
+	Description = {
+		"@eng:Minimum scale values for the skeletal animations contained in the texture",
+	};
+	InputPins = {
+		"$4168AA0B",
+	};
+	OutputPins = {
+		"$0BFABE33",
+	};
+	ExportedName = "SkeletalAnimationUseBonesScale.AnimScalesBoundsMin";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimationUseBonesScale",
+	};
+}
+CParticleNodePinIn	$4168AA0B
+{
+	SelfName = "DefaultValue";
+	Owner = "$A5447DEF";
+}
+CParticleNodePinOut	$0BFABE33
+{
+	SelfName = "Value";
+	Owner = "$A5447DEF";
+}
+CParticleNodeTemplateExport	$117B401A
+{
+	Description = {
+		"@eng:Maximum scale values for the skeletal animations contained in the texture",
+	};
+	InputPins = {
+		"$58C4B147",
+	};
+	OutputPins = {
+		"$58605E5E",
+	};
+	ExportedName = "SkeletalAnimationUseBonesScale.AnimScalesBoundsMax";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SkeletalAnimationUseBonesScale",
+	};
+}
+CParticleNodePinIn	$58C4B147
+{
+	SelfName = "DefaultValue";
+	Owner = "$117B401A";
+}
+CParticleNodePinOut	$58605E5E
+{
+	SelfName = "Value";
+	Owner = "$117B401A";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Billboard.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Ribbon.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Triangle.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Triangle.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {

--- a/PopcornFX/Library/PopcornFXCore/Materials/Transparent_Mesh.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Transparent_Mesh.pkma
@@ -1,4 +1,4 @@
-Version = 2.13.0.13591;
+Version = 2.14.0.14607;
 CParticleRendererFeatureSet	$6B70D015
 {
 	RendererFeatures = {
@@ -9,11 +9,13 @@ CParticleRendererFeatureSet	$6B70D015
 		"$FF800025",
 		"$D857A09F",
 		"$9154ABA0",
+		"$21461F4D",
 		"$4B933A29",
 		"$EAC726E3",
 		"$9154DFA0",
 		"$178EB8B0",
 		"$30A73448",
+		"$D46EA531",
 	};
 }
 CParticleRendererFeatureDesc	$4126ECB5
@@ -83,4 +85,14 @@ CParticleRendererFeatureDesc	$30A73448
 {
 	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
 	RendererFeatureName = "UseVertexColors";
+}
+CParticleRendererFeatureDesc	$21461F4D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$D46EA531
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "MeshLOD";
 }

--- a/PopcornFX/Library/PopcornFXCore/Shaders/AnimatedMesh.vert
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/AnimatedMesh.vert
@@ -1,0 +1,222 @@
+
+struct 	SBoneTransform
+{
+	vec4 	m_Rotation;
+	vec3 	m_Position;
+	vec3	m_Scale;
+};
+
+#if 	defined(HAS_SkeletalAnimationUseBonesScale)
+#	define PIXELS_PER_BONE 	3.0f
+#else
+#	define PIXELS_PER_BONE 	2.0f
+#endif
+
+SBoneTransform  LerpBoneTransforms(IN(SBoneTransform) a, IN(SBoneTransform) b, float v)
+{
+	SBoneTransform 	c;
+	vec4 			rotationB = b.m_Rotation;
+
+	if (dot(a.m_Rotation, b.m_Rotation) < 0.0f)
+		rotationB *= -1.0f;
+	c.m_Rotation = normalize(mix(a.m_Rotation, rotationB, v));
+	c.m_Position = mix(a.m_Position, b.m_Position, v);
+	c.m_Scale = mix(a.m_Scale, b.m_Scale, v);
+	return c;
+}
+
+vec3 RemapPositionsFromUnormToBounds(vec3 value VS_ARGS)
+{
+	vec3 	minBounds = GET_CONSTANT(Material, SkeletalAnimation_AnimPositionsBoundsMin);
+	vec3 	maxBounds = GET_CONSTANT(Material, SkeletalAnimation_AnimPositionsBoundsMax);
+	vec3 	range = maxBounds - minBounds;
+	return minBounds + value * range;
+}
+
+#if 	defined(HAS_SkeletalAnimationUseBonesScale)
+vec3 RemapScalesFromUnormToBounds(vec3 value VS_ARGS)
+{
+	vec3 	minBounds = GET_CONSTANT(Material, SkeletalAnimationUseBonesScale_AnimScalesBoundsMin);
+	vec3 	maxBounds = GET_CONSTANT(Material, SkeletalAnimationUseBonesScale_AnimScalesBoundsMax);
+	vec3 	range = maxBounds - minBounds;
+	return minBounds + value * range;
+}
+#endif
+
+SBoneTransform 	ReadBoneTransforms(int animationId, float boneId, float animationCursor VS_ARGS)
+{
+	// Texture info:
+	vec2 animTexResol = vec2(GET_CONSTANT(Material, SkeletalAnimation_AnimTextureResolution));
+	vec2 pxlUvSize = 1.0f / animTexResol;
+	vec2 offsetToBottomPixel = vec2(0.0f, pxlUvSize.y);
+	// Remap anim cursor to start the sampling in the middle of the first pixel and finish in the middle of the last one:
+	float animCursorToUvRange = animationCursor * (1.0f - pxlUvSize.x);
+	float animCursorToPrevPixel = mod(animCursorToUvRange, pxlUvSize.x);
+	float snappedAnimCursor = (animCursorToUvRange - animCursorToPrevPixel) + pxlUvSize.x * 0.5f;
+	// UV offset to read from correct animation index:
+	float animCount = float(GET_CONSTANT(Material, SkeletalAnimation_AnimTracksCount));
+	float animationUVOffset = ((animTexResol.y / animCount) * pxlUvSize.y) * float(animationId);
+	// Start pixel to read from:
+	vec2 animUV = vec2(snappedAnimCursor, boneId * PIXELS_PER_BONE * pxlUvSize.y + animationUVOffset);
+
+	SBoneTransform	boneTransform;
+
+	// Sample the texture:
+	vec4 position = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV + offsetToBottomPixel * 0.5f, 0);
+	vec4 rotation = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV + offsetToBottomPixel * 1.5f, 0);
+	boneTransform.m_Rotation = rotation * 2.0f - 1.0f;
+	boneTransform.m_Position = RemapPositionsFromUnormToBounds(position.xyz VS_PARAMS);
+#if 	defined(HAS_SkeletalAnimationUseBonesScale)
+	vec4 scale = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV + offsetToBottomPixel * 2.5f, 0);
+	boneTransform.m_Scale = RemapScalesFromUnormToBounds(scale.xyz VS_PARAMS);
+#else
+	boneTransform.m_Scale = vec3(1.0f, 1.0f, 1.0f);
+#endif
+
+#if 	defined(HAS_SkeletalAnimationInterpolate)
+	SBoneTransform	boneTransform1;
+
+	float snappedAnimCursor1 = (animCursorToUvRange + (pxlUvSize.x - animCursorToPrevPixel)) + pxlUvSize.x * 0.5f;
+	float currentLerpRatio = animCursorToPrevPixel / pxlUvSize.x;
+	vec2 animUV1 = vec2(snappedAnimCursor1, float(boneId) * PIXELS_PER_BONE * pxlUvSize.y + animationUVOffset);
+
+	// Sample the texture:
+	vec4 position1 = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV1 + offsetToBottomPixel * 0.5f, 0);
+	vec4 rotation1 = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV1 + offsetToBottomPixel * 1.5f, 0);
+	boneTransform1.m_Rotation = rotation1 * 2.0f - 1.0f;
+	boneTransform1.m_Position = RemapPositionsFromUnormToBounds(position1.xyz VS_PARAMS);
+#if 	defined(HAS_SkeletalAnimationUseBonesScale)
+	vec4 scale1 = SAMPLELOD(SkeletalAnimation_AnimationTexture, animUV1 + offsetToBottomPixel * 2.5f, 0);
+	boneTransform1.m_Scale = RemapScalesFromUnormToBounds(scale1.xyz VS_PARAMS);
+#else
+	boneTransform1.m_Scale = vec3(1.0f, 1.0f, 1.0f);
+#endif
+	boneTransform = LerpBoneTransforms(boneTransform, boneTransform1, currentLerpRatio);
+#endif
+
+	return boneTransform;
+}
+
+float RemapValue(float value, float min1, float max1, float min2, float max2)
+{
+	float 	value_01 = (value - min1) / (max1 - min1);
+	return value_01 * (max2 - min2) + min2;
+}
+
+mat4 QuatToMat4(vec4 quat)
+{
+    mat4 m = mat4(VEC4_ZERO, VEC4_ZERO, VEC4_ZERO, VEC4_ZERO);
+    float x = quat.x, y = quat.y, z = quat.z, w = quat.w;
+    float x2 = x + x, y2 = y + y, z2 = z + z;
+    float xx = x * x2, xy = x * y2, xz = x * z2;
+    float yy = y * y2, yz = y * z2, zz = z * z2;
+    float wx = w * x2, wy = w * y2, wz = w * z2;
+
+    m[0][0] = 1.0 - (yy + zz);
+    m[1][0] = xy - wz;
+    m[2][0] = xz + wy;
+
+    m[0][1] = xy + wz;
+    m[1][1] = 1.0 - (xx + zz);
+    m[2][1] = yz - wx;
+
+    m[0][2] = xz - wy;
+    m[1][2] = yz + wx;
+    m[2][2] = 1.0 - (xx + yy);
+
+    m[3][3] = 1.0;
+    return m;
+}
+
+mat4  	BoneTransformToMatrix(SBoneTransform tr)
+{
+	mat4 res = QuatToMat4(tr.m_Rotation);
+	res[3] = vec4(tr.m_Position, 1.0f);
+	res[0].xyz *= tr.m_Scale;
+	res[1].xyz *= tr.m_Scale;
+	res[2].xyz *= tr.m_Scale;	
+	return BUILD_MAT4(res[0], res[1], res[2], res[3]);
+}
+
+mat4 	LerpMatrix(mat4 m0, mat4 m1, float ratio)
+{
+	mat4 	res;
+	
+	res[0] = mix(m0[0], m1[0], ratio);
+	res[1] = mix(m0[1], m1[1], ratio);
+	res[2] = mix(m0[2], m1[2], ratio);
+	res[3] = mix(m0[3], m1[3], ratio);
+	return res;
+}
+
+void    VertexMain(IN(SVertexInput) vInput, INOUT(SVertexOutput) vOutput VS_ARGS)
+{
+	mat4 	meshTransform = GetMeshMatrix(vInput VS_PARAMS);
+	
+#if 	defined(VOUTPUT_fragSkeletalAnimation_CurrentAnimTrack) && defined(VOUTPUT_fragSkeletalAnimation_AnimationCursor) && defined(VINPUT_BoneIds)
+	mat4 animTr = BUILD_MAT4(VEC4_ZERO, VEC4_ZERO, VEC4_ZERO, VEC4_ZERO);
+
+	int boneIdx = 0;
+	while (boneIdx < 4)
+	{
+		SBoneTransform boneTr = ReadBoneTransforms(	vOutput.fragSkeletalAnimation_CurrentAnimTrack,
+													vInput.BoneIds[boneIdx],
+													vOutput.fragSkeletalAnimation_AnimationCursor
+													VS_PARAMS);
+		mat4 boneMat = BoneTransformToMatrix(boneTr);
+#	if defined(HAS_SkeletalAnimationInterpolateTracks)
+		SBoneTransform boneTr2 = ReadBoneTransforms(vOutput.fragSkeletalAnimationInterpolateTracks_NextAnimTrack,
+													vInput.BoneIds[boneIdx],
+													vOutput.fragSkeletalAnimationInterpolateTracks_NextAnimationCursor
+													VS_PARAMS);
+		mat4 boneMat2 = BoneTransformToMatrix(boneTr2);
+		boneMat = LerpMatrix(boneMat, boneMat2, vOutput.fragSkeletalAnimationInterpolateTracks_TransitionRatio);
+#	endif
+		animTr[0] += boneMat[0] * vInput.BoneWeights[boneIdx];
+		animTr[1] += boneMat[1] * vInput.BoneWeights[boneIdx];
+		animTr[2] += boneMat[2] * vInput.BoneWeights[boneIdx];
+		animTr[3] += boneMat[3] * vInput.BoneWeights[boneIdx];
+		++boneIdx;
+	}
+
+	mat4 finalTransform = animTr;
+	mat4 user2lhz = GET_CONSTANT(SceneInfo, UserToLHZ);
+	mat4 lhz2user = GET_CONSTANT(SceneInfo, LHZToUser);
+	finalTransform = mul(lhz2user, finalTransform);
+	finalTransform = mul(finalTransform, user2lhz);
+	finalTransform = mul(meshTransform, finalTransform);
+	vec3 worldPos = mul(finalTransform, vec4(vInput.Position, 1.0f)).xyz;
+
+#	if 	defined(HAS_SkeletalAnimationUseBonesScale)
+	mat4 transformNoScale = BUILD_MAT4(	normalize(GET_MATRIX_X_AXIS(finalTransform)),
+										normalize(GET_MATRIX_Y_AXIS(finalTransform)),
+										normalize(GET_MATRIX_Z_AXIS(finalTransform)),
+										GET_MATRIX_W_AXIS(finalTransform));
+#	else
+	mat4 transformNoScale = finalTransform;
+#	endif
+
+#	if	defined(VINPUT_Normal)
+	vOutput.fragNormal = mul(transformNoScale, vec4(vInput.Normal.xyz, 0)).xyz;
+#	endif
+#	if	defined(VINPUT_Tangent)
+	vOutput.fragTangent = vec4(mul(transformNoScale, vec4(vInput.Tangent.xyz, 0)).xyz, vInput.Tangent.w);
+#	endif
+
+#else
+	vec3 worldPos = mul(meshTransform, vec4(vInput.Position.xyz, 1.0f)).xyz;
+#endif
+
+	vOutput.VertexPosition = mul(GET_CONSTANT(SceneInfo, ViewProj), vec4(worldPos, 1.0f));
+
+#if	defined(VOUTPUT_fragWorldPosition)
+	vOutput.fragWorldPosition = worldPos;
+#endif
+#if	defined(VOUTPUT_fragViewProjPosition)
+	vOutput.fragViewProjPosition = vOutput.VertexPosition;
+#endif
+#if	defined(VINPUT_Enabled)
+	if (vInput.Enabled == 0u)
+		vOutput.geomSize = 0.f;
+#endif
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Billboard.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Billboard.frag
@@ -77,6 +77,7 @@ vec3	toCubemapSpace(vec3 value FS_ARGS)
 {
 	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
 	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	valueRHY.xz = mul(GET_CONSTANT(EnvironmentMapInfo, Rotation), valueRHY.xz);
 	return valueRHY;
 }
 

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Mesh.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Mesh.frag
@@ -32,7 +32,39 @@ void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_
 	color *= fInput.fragColor0;
 #endif
 
-vec2 fragUV0 = fInput.fragUV0;
+vec2	fragUV0 = fInput.fragUV0;
+
+#if     defined(HAS_Diffuse) || defined(HAS_Lit) || defined(HAS_LegacyLit) || defined(HAS_Emissive) // has texture sampling
+
+#if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2	fragUV1 = fInput.fragUV1;
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
 
 #if		defined(HAS_TransformUVs)
 	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
@@ -40,9 +72,20 @@ vec2 fragUV0 = fInput.fragUV0;
 	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
 	vec2	UVScale = fInput.fragTransformUVs_UVScale;
 	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
-	vec2	oldFragUV0 = fragUV0;	
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
+	vec2	oldFragUV0 = fragUV0;
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)	
 	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
-	fragUV0 = fract(fragUV0);
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
 	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
 #endif
 
@@ -54,6 +97,20 @@ vec2 fragUV0 = fInput.fragUV0;
 		{
 			textureColor.a = SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
 		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
 #	endif
 
 #if defined(HAS_DiffuseRamp)
@@ -81,7 +138,14 @@ vec2 fragUV0 = fInput.fragUV0;
 
 #if     defined(HAS_Lit)
 
-	vec3    normalTex =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+	vec3	normalTex =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3	normalTex1 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex1, blendMix);
+	}
+#endif
 
 	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
 	
@@ -112,6 +176,13 @@ vec2 fragUV0 = fInput.fragUV0;
 #elif   defined(HAS_LegacyLit)
 
 	vec3    normalTex =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+#if 	defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex1 =  SAMPLE(LegacyLit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex1, blendMix);
+	}
+#endif
 	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
 	
 #	if	defined(HAS_TransformUVs)
@@ -144,9 +215,18 @@ vec2 fragUV0 = fInput.fragUV0;
 #if defined(HAS_Emissive)
 
 	vec3 emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;	
-	#if defined(HAS_EmissiveRamp)
+
+#	if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#	endif
+
+#	if defined(HAS_EmissiveRamp)
 		emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
-	#endif
+#	endif
 	emissive.rgb += emissiveColor1 * fInput.fragEmissive_EmissiveColor;
 
 #endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Ribbon.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Ribbon.frag
@@ -96,6 +96,7 @@ vec3	toCubemapSpace(vec3 value FS_ARGS)
 {
 	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
 	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	valueRHY.xz = mul(GET_CONSTANT(EnvironmentMapInfo, Rotation), valueRHY.xz);
 	return valueRHY;
 }
 

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Triangle.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Triangle.frag
@@ -77,6 +77,7 @@ vec3	toCubemapSpace(vec3 value FS_ARGS)
 {
 	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
 	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	valueRHY.xz = mul(GET_CONSTANT(EnvironmentMapInfo, Rotation), valueRHY.xz);
 	return valueRHY;
 }
 

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKLighting.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKLighting.h
@@ -83,6 +83,7 @@ vec3	toCubemapSpace(vec3 value FS_ARGS)
 {
 	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
 	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	valueRHY.xz = mul(GET_CONSTANT(EnvironmentMapInfo, Rotation), valueRHY.xz);
 	return valueRHY;
 }
 

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Particle_Master.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Particle_Master.frag
@@ -88,6 +88,7 @@ vec3	toCubemapSpace(vec3 value FS_ARGS)
 {
 	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
 	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	valueRHY.xz = mul(GET_CONSTANT(EnvironmentMapInfo, Rotation), valueRHY.xz);
 	return valueRHY;
 }
 

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Transparent_Mesh.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Transparent_Mesh.frag
@@ -28,16 +28,60 @@ void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_
 	color *= fInput.fragColor0;
 #endif
 
-vec2 fragUV0 = fInput.fragUV0;
-#if		defined(HAS_TransformUVs)
+vec2	fragUV0 = fInput.fragUV0;
+
+#if     defined(HAS_Diffuse) || defined(HAS_Emissive) // has texture sampling
+
+#if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2	fragUV1 = fInput.fragUV1;
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
+
+#if	defined(HAS_TransformUVs)
 	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
 	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
 	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
 	vec2	UVScale = fInput.fragTransformUVs_UVScale;
 	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
 	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
 	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
-	fragUV0 = fract(fragUV0);
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
 	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
 #endif
 
@@ -49,6 +93,20 @@ vec2 fragUV0 = fInput.fragUV0;
 		{
 			textureColor.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
 		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
 #	endif
 
 #if defined(HAS_DiffuseRamp)
@@ -80,10 +138,20 @@ vec2 fragUV0 = fInput.fragUV0;
 #endif
 
 #if	defined(HAS_Emissive)
-	vec3	emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;	
-#if	defined(HAS_EmissiveRamp)
+	vec3	emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+	
+#	if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3	emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#	endif
+
+#	if	defined(HAS_EmissiveRamp)
 	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
-#endif
+#	endif
+
 	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
 	color.rgb += emissiveColor1.rgb;
 #endif

--- a/PopcornFX/Library/PopcornFXCore/Templates/Color.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Color.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8af5ee862466ab2ccd197f36fc42ed06b66038bef16222e885b704de2e23186
-size 75221
+oid sha256:c5d7c9c578acbf82c71c525863b019e5747c89a58fbe9da635b2269faad69147
+size 81075

--- a/PopcornFX/Library/PopcornFXCore/Templates/Core.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Core.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bbaa2a8eafb99a60b7beb8eeadf7a95fdfec0e7039efb6671ab71a664724498a
-size 397549
+oid sha256:bc3eee7e03bf699fad9037160ce9bbd7aaf97ba4e03829ff6a661fde9f89a479
+size 419145

--- a/PopcornFX/Library/PopcornFXCore/Templates/CurvePresets.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/CurvePresets.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:905b49e50451c21f3db4c3e030654eefd4934b184e5064890d1e6969cfcd06b6
+oid sha256:dca9186712c50c138e670eb4f319a3f30d5d89ae52e86f9f5bf7bf1aa2dd1e69
 size 20838

--- a/PopcornFX/Library/PopcornFXCore/Templates/Debug.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Debug.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5db44416dd9a7b06f426dfd7f72d90b5c1d01673b41afb3f319d2bb35525917a
+oid sha256:a4d03673958cd4c6b1fe1701b24ccc280b651735f3be31bada054e6c62ec98e5
 size 86552

--- a/PopcornFX/Library/PopcornFXCore/Templates/Dynamics.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Dynamics.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fb9c39d2e60f4e164f7129afc571585d68a7d9b5328b6767c13091e08da9765
+oid sha256:850bdf66ad72bab312eb94eee9db82ff1ab6b1f752f23740c693c99d62a32bfe
 size 691522

--- a/PopcornFX/Library/PopcornFXCore/Templates/Events.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Events.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e46057b0c772c59c0dd20099adb83a09a7c9bd32a6c301dff633a940ed2934d0
+oid sha256:5c38e43a59186528c0a92b4d7bee26881eaaac7154ad2a307b51f8d365235d0f
 size 369182

--- a/PopcornFX/Library/PopcornFXCore/Templates/Legacy.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Legacy.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d3b0a1507cd439d09956207734afc900c281691fdcdbff0577be1c8cc074671
+oid sha256:41f6e58c5e5544ff53f39ab0cb80c211b5f87e7bdf7e4fbeee560db03ab2eaf3
 size 453057

--- a/PopcornFX/Library/PopcornFXCore/Templates/Placement.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Placement.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b604609e50d65602d8f1afde913f11c9dcd0f6ef307bc63efbcc5fc92742b9d
+oid sha256:6f009c46e5425fb959607a5a0041856904b8b202063522d8fc4b1d2fa0468f6f
 size 192375

--- a/PopcornFX/Library/PopcornFXCore/Templates/Samplers.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Samplers.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1902fae4ada6aa4609814498accf79adf4f9c1ab0b873bcd0eafc6ef8272a7d
+oid sha256:524427f9d1f3ee13931e2ccb8ba2f3f56eddf31e91df9542c6adf0760414ea30
 size 343899

--- a/PopcornFX/Library/PopcornFXCore/Templates/Trails.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Trails.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9925c57c97c54d0dd8572397101ecfa47938b11d9c0de3868acc587a48542945
-size 113127
+oid sha256:fe683a846696d43ed169ea82148c4d4bf86388acbaa4023d4d6bd05f5aeb418d
+size 113228

--- a/PopcornFX/Library/PopcornFXCore/Templates/Utils.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Utils.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:941e37bfd420fce3714af487de5f610731bcbc825a582e2881d6c658228e6c93
-size 456296
+oid sha256:60ab02590facf7572f3872d9f6fbf831a50024060395448c9f78b1fc3188cd4b
+size 456955

--- a/PopcornFX/Library/Test_Simple.pkfx
+++ b/PopcornFX/Library/Test_Simple.pkfx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5389a92e894a56ecf6871a8d56c42534f24ea8ca44251f81cff29a24edb80da
+oid sha256:5e7e1c5c3d51d3da31761f1e3e449f3a73cc821696b0ca2c7dfbacfd3f1864ae
 size 30036

--- a/PopcornFX/PopcornProject.pkproj
+++ b/PopcornFX/PopcornProject.pkproj
@@ -1,4 +1,4 @@
-Version = 2.13.1.13966;
+Version = 2.14.1.14777;
 CProjectSettings	$D857A09F
 {
 	General = "$35A36C4E";


### PR DESCRIPTION
Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>

Updated PopcornFX assets to 2.14 which was required for the fix for dev-o3de shaders.

The update was performed using PopcornFX Project Launcher.