### PR TITLE
Basic Spring Arm functionality & minor fixes

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml
@@ -12,6 +12,11 @@
 
     <Include File="Source/MultiplayerSampleTypes.h"/>
 
+    <ArchetypeProperty Type="bool" Name="EnableCollision" Init="true" ExposeToEditor="true" Description="Enable collision" />
+    <ArchetypeProperty Type="float" Name="CollisionOffset" Init="0.01" ExposeToEditor="true" Description="Collision offset" />
+    <ArchetypeProperty Type="float" Name="MinFollowDistance" Init="0.1" ExposeToEditor="true" Description="Minimum follow distance" />
+    <ArchetypeProperty Type="float" Name="MaxFollowDistance" Init="2.0" ExposeToEditor="true" Description="Maximum follow distance" />
+
     <NetworkProperty Type="AZ::Vector3" Name="AimAngles" Init="AZ::Vector3::CreateZero()" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="Current aim direction of this player"/>
     <NetworkProperty Type="bool" Name="SyncAimImmediate" Init="false" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="false" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="true" Description="Flag to force aim angles sync without interpolation"/>
 </Component>

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -169,7 +169,7 @@ namespace MultiplayerSample
         aimAngles.SetZ(NormalizeHeading(aimAngles.GetZ() - playerInput->m_viewYaw * cl_AimStickScaleZ * cl_MaxMouseDelta));
         aimAngles.SetX(NormalizeHeading(aimAngles.GetX() - playerInput->m_viewPitch * cl_AimStickScaleX * cl_MaxMouseDelta));
         aimAngles.SetX(
-            NormalizeHeading(AZ::GetClamp(aimAngles.GetX(), -AZ::Constants::QuarterPi * 0.75f, AZ::Constants::QuarterPi * 0.75f)));
+            NormalizeHeading(AZ::GetClamp(aimAngles.GetX(), -AZ::Constants::QuarterPi * 1.5f, AZ::Constants::QuarterPi * 1.5f)));
         GetNetworkSimplePlayerCameraComponentController()->SetAimAngles(aimAngles);
 
         const AZ::Quaternion newOrientation = AZ::Quaternion::CreateRotationZ(aimAngles.GetZ());

--- a/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
@@ -10,11 +10,16 @@
 #include <Source/Components/NetworkSimplePlayerCameraComponent.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Components/CameraBus.h>
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <Multiplayer/IMultiplayer.h>
+#include <DebugDraw/DebugDrawBus.h>
 
 namespace MultiplayerSample
 {
-    AZ_CVAR(AZ::Vector3, cl_cameraOffset, AZ::Vector3(0.5f, -2.0f, 1.5f), nullptr, AZ::ConsoleFunctorFlags::Null, "Offset to use for the player camera");
+    AZ_CVAR(AZ::Vector3, cl_cameraOffset, AZ::Vector3(0.5f, 0.f, 1.5f), nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Offset to use for the player camera");
+    AZ_CVAR(AZ::Vector3, cl_cameraColliderSize, AZ::Vector3(0.7f, 0.1f, 0.5f), nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Temporary collider size for player camera");
+    AZ_CVAR(bool, cl_drawCameraCollider, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Draw the camera collider");
 
     NetworkSimplePlayerCameraComponentController::NetworkSimplePlayerCameraComponentController(NetworkSimplePlayerCameraComponent& parent)
         : NetworkSimplePlayerCameraComponentControllerBase(parent)
@@ -24,6 +29,12 @@ namespace MultiplayerSample
 
     void NetworkSimplePlayerCameraComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+        m_physicsSceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        if (m_physicsSceneInterface)
+        {
+            m_physicsSceneHandle = m_physicsSceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
+        }
+
         // Synchronize aim angles with initial transform
         AZ::Vector3& aimAngles = ModifyAimAngles();
         aimAngles.SetZ(GetEntity()->GetTransform()->GetLocalRotation().GetZ());
@@ -45,7 +56,10 @@ namespace MultiplayerSample
 
     void NetworkSimplePlayerCameraComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        AZ::TickBus::Handler::BusDisconnect();
+        if(AZ::TickBus::Handler::BusIsConnected())
+        { 
+            AZ::TickBus::Handler::BusDisconnect();
+        }
     }
 
     float NetworkSimplePlayerCameraComponentController::GetCameraYaw() const
@@ -78,14 +92,17 @@ namespace MultiplayerSample
         return GetAimAnglesPrevious().GetY();
     }
 
-    void NetworkSimplePlayerCameraComponentController::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    AZ::Transform NetworkSimplePlayerCameraComponentController::GetCameraTransform(bool collisionEnabled) const
     {
-        if (m_activeCameraEntity != nullptr && m_activeCameraEntity->GetState() == AZ::Entity::State::Active)
+        // exclude roll from any rotation calculations
+        const AZ::Quaternion targetYaw = AZ::Quaternion::CreateRotationZ(GetCameraYaw());
+        const AZ::Quaternion targetRotation = targetYaw * AZ::Quaternion::CreateRotationX(GetCameraPitch());
+        AZ::Quaternion aimRotation = targetRotation;
+
+        if (IsNetEntityRoleAutonomous())
         {
-            const AZ::Quaternion targetRotation = AZ::Quaternion::CreateRotationZ(GetCameraYaw()) * AZ::Quaternion::CreateRotationX(GetCameraPitch());
             const float blendFactor = Multiplayer::GetMultiplayer()->GetCurrentBlendFactor();
-            
-            AZ::Quaternion aimRotation = targetRotation;
+
             if (!GetSyncAimImmediate() && !AZ::IsClose(blendFactor, 1.0f))
             {
                 const AZ::Quaternion prevRotation = AZ::Quaternion::CreateRotationZ(GetCameraYawPrevious()) * AZ::Quaternion::CreateRotationX(GetCameraPitchPrevious());
@@ -94,15 +111,88 @@ namespace MultiplayerSample
                     aimRotation = prevRotation.Slerp(targetRotation, blendFactor).GetNormalized();
                 }
             }
-            const AZ::Vector3 targetTranslation = GetEntity()->GetTransform()->GetWorldTM().GetTranslation();
-            const AZ::Vector3 cameraOffset = aimRotation.TransformVector(cl_cameraOffset);
-            const AZ::Transform cameraTransform = AZ::Transform::CreateFromQuaternionAndTranslation(aimRotation, targetTranslation + cameraOffset);
-            m_activeCameraEntity->GetTransform()->SetWorldTM(cameraTransform);
+        }
+
+        const AZ::Vector3 targetTranslation = GetEntity()->GetTransform()->GetWorldTM().GetTranslation();
+        const AZ::Vector3 cameraPivotOffset = targetYaw.TransformVector(cl_cameraOffset);
+
+        if(collisionEnabled)
+        { 
+            AZ::Transform cameraTransform = AZ::Transform::CreateFromQuaternionAndTranslation(aimRotation, targetTranslation + cameraPivotOffset);
+            ApplySpringArm(cameraTransform);
+            return cameraTransform;
+        }
+        else
+        { 
+            const AZ::Vector3 cameraOffset = cameraPivotOffset + aimRotation.TransformVector(AZ::Vector3(0.f, GetMaxFollowDistance(), 0.f));
+            return AZ::Transform::CreateFromQuaternionAndTranslation(aimRotation, targetTranslation + cameraOffset);
+        }
+    }
+
+    void NetworkSimplePlayerCameraComponentController::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (m_activeCameraEntity != nullptr && m_activeCameraEntity->GetState() == AZ::Entity::State::Active)
+        {
+            const AZ::Transform& transform = GetCameraTransform(GetEnableCollision());
+            m_activeCameraEntity->GetTransform()->SetWorldTM(transform);
         }
 
         if (GetSyncAimImmediate())
         {
             SetSyncAimImmediate(false);
+
+            if (!m_activeCameraEntity)
+            {
+                // the server no longer needs to tick after the initial sync
+                AZ::TickBus::Handler::BusDisconnect();
+            }
+        }
+    }
+
+    void NetworkSimplePlayerCameraComponentController::ApplySpringArm(AZ::Transform& inOutTransform) const
+    {
+        // TODO replace cl_cameraColliderSize with dynamic box based on the camera near plane world dimensions
+        const AZ::EntityId ignoreEntityId = GetEntityId();
+        const AZ::Vector3 cameraPivot = inOutTransform.GetTranslation();
+        const AZ::Vector3 direction = -inOutTransform.GetBasisY();
+        const float maxDistance = GetMaxFollowDistance();
+        float distance = maxDistance;
+
+        // trace from the target to the camera position
+        auto request = AzPhysics::ShapeCastRequestHelpers::CreateBoxCastRequest(
+                    cl_cameraColliderSize, inOutTransform, direction, maxDistance,
+                    AzPhysics::SceneQuery::QueryType::StaticAndDynamic,
+                    AzPhysics::CollisionGroup::All, 
+                    [ignoreEntityId](const AzPhysics::SimulatedBody* body, [[maybe_unused]] const Physics::Shape* shape)
+                    {
+                        return body->GetEntityId() != ignoreEntityId ? AzPhysics::SceneQuery::QueryHitType::Block
+                                                             : AzPhysics::SceneQuery::QueryHitType::None;
+                    });
+        AzPhysics::SceneQueryHits result = m_physicsSceneInterface->QueryScene(m_physicsSceneHandle, &request);
+        if (result && !result.m_hits.empty())
+        {
+            // include the collision offset so we are not intersecting the surface
+            distance = result.m_hits[0].m_distance - GetCollisionOffset();
+            distance = AZ::GetClamp(distance, GetMinFollowDistance(), maxDistance);
+        }
+
+        inOutTransform.SetTranslation(cameraPivot + direction * distance);
+
+        if (cl_drawCameraCollider && distance < maxDistance)
+        {
+            if (auto debugDraw = DebugDraw::DebugDrawRequestBus::FindFirstHandler(); debugDraw != nullptr)
+            {
+                const AZ::Vector3 colliderSize = cl_cameraColliderSize;
+                debugDraw->DrawObb(
+                    AZ::Obb::CreateFromPositionRotationAndHalfLengths(
+                        inOutTransform.GetTranslation(),
+                        inOutTransform.GetRotation(),
+                        colliderSize * 0.5f),
+                    AZ::Color(1.f,0.f,0.f,0.1f), 
+                    1.f);
+            }
+
+            inOutTransform.SetTranslation(cameraPivot + direction * maxDistance);
         }
     }
 

--- a/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.h
+++ b/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.h
@@ -9,6 +9,12 @@
 
 #include <Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzFramework/Physics/Common/PhysicsTypes.h>
+
+namespace AzPhysics
+{
+    class SceneInterface;
+}
 
 namespace MultiplayerSample
 {
@@ -30,6 +36,8 @@ namespace MultiplayerSample
         float GetCameraPitchPrevious() const;
         float GetCameraRollPrevious() const;
 
+        AZ::Transform GetCameraTransform(bool collisionEnabled) const;
+
     private:
         //! AZ::TickBus interface
         //! @{
@@ -37,7 +45,11 @@ namespace MultiplayerSample
         int GetTickOrder() override;
         //! @}
 
+        void ApplySpringArm(AZ::Transform& inOutTransform) const;
+
         AZ::Entity* m_activeCameraEntity = nullptr;
         bool m_aiEnabled = false;
+        AzPhysics::SceneInterface* m_physicsSceneInterface = nullptr;
+        AzPhysics::SceneHandle m_physicsSceneHandle = AzPhysics::InvalidSceneHandle;
     };
 }

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -371,12 +371,8 @@ namespace MultiplayerSample
         GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
             aznumeric_cast<uint32_t>(CharacterAnimState::Aiming), weaponInput->m_draw);
 
-        for (AZStd::size_t weaponIndex = 0; weaponIndex < MaxWeaponsPerComponent; ++weaponIndex)
-        {
-            const CharacterAnimState animState = CharacterAnimState::Shooting;
-            GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
-                aznumeric_cast<uint32_t>(animState), weaponInput->m_firing.GetBit(static_cast<uint32_t>(weaponIndex)));
-        }
+        GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
+            aznumeric_cast<uint32_t>(CharacterAnimState::Shooting), weaponInput->m_firing.AnySet());
 
         const AZ::Transform cameraTransform = GetNetworkSimplePlayerCameraComponentController()->GetCameraTransform(/*collisionEnabled=*/false);
 

--- a/Gem/Code/Source/Weapons/WeaponGathers.cpp
+++ b/Gem/Code/Source/Weapons/WeaponGathers.cpp
@@ -115,7 +115,7 @@ namespace MultiplayerSample
             AZ::Vector3 travelDistance = (segmentStepOffset * nextSegmentStartTime); // Total distance our shot has traveled as of this cast, ignoring arc-length due to gravity
             AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);
 
-            const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
+            const AZ::Transform currSegTransform = AZ::Transform::CreateLookAt(currSegmentPosition, nextSegmentPosition);
             const AZ::Vector3 segSweep = nextSegmentPosition - currSegmentPosition;
 
             IntersectFilter filter(currSegTransform, segSweep, AzPhysics::SceneQuery::QueryType::StaticAndDynamic,
@@ -138,6 +138,17 @@ namespace MultiplayerSample
             if (((outResults.size() > 0) && !gatherParams.m_multiHit) || (travelDistance.GetLengthSq() > maxTravelDistanceSq))
             {
                 result = ShotResult::ShouldTerminate;
+                if (bg_DrawPhysicsRaycasts && !outResults.empty())
+                {
+                    DebugDraw::DebugDrawRequestBus::Broadcast
+                    (
+                        &DebugDraw::DebugDrawRequests::DrawSphereAtLocation,
+                        outResults[0].m_position,
+                        /*radius=*/0.1f,
+                        AZ::Colors::Green,
+                        /*duration=*/10.0f
+                    );
+                }
                 break;
             }
 


### PR DESCRIPTION
This change adds a collider to the camera which is used to move the camera in front of objects that obstruct the player (also known as a spring arm).  It is a basic version because it just moves towards the camera pivot offset, instead of moving toward the player head (and fading the player model out).  This means it still clips through geometry on the right side of the player when running along walls.

**Fixes**
- Fix force impulse from weapons so it's based on the direction of weapon impact instead of the direction from center of mass - PhysX should handle that math for us so long as we provide the correct impulse direction and location.
- Fix minor orientation in segment shapecast query not using gravity affected orientation

**Testing**
- In editor with physx_debug 1 & 2 

Future improvements
- base camera collider size on near plane world dimensions
- spring arm should move toward the player head to avoid collisions on right side
- player model should fade out when the camera is close enough (first person view?)