### PR TITLE
Switch from BURT to YBot

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml
@@ -16,6 +16,8 @@
 
     <NetworkProperty Type="CharacterAnimStateBitset" Name="ActiveAnimStates" Init="false" ReplicateFrom="Authority" ReplicateTo="Client" IsRewindable="true" IsPredictable="true" IsPublic="true" Container="Object" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="false" Description="Bitset of active animation states" />
 
+    <ArchetypeProperty Type="AZStd::string" Name="MovementDirectionParamName"  Init="" ExposeToEditor="true" Description="Anim graph movement direction parameter"/>
+    <ArchetypeProperty Type="AZStd::string" Name="MovementSpeedParamName"  Init="" ExposeToEditor="true" Description="Anim graph movement speed parameter"/>
     <ArchetypeProperty Type="AZStd::string" Name="VelocityParamName"  Init="" ExposeToEditor="true" Description="Anim graph velocity parameter"/>
     <ArchetypeProperty Type="bool" Name="VelocityIsLocal"  Init="true" ExposeToEditor="true" Description="True if velocity is relative to player"/>
     <ArchetypeProperty Type="bool" Name="TurningEnabled"  Init="false" ExposeToEditor="true" Description="True if y is for speed and x is for turning"/>

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -98,9 +98,12 @@ namespace MultiplayerSample
         }
         m_networkRequests->UpdateActorExternal(deltaTime);
 
-        if (m_velocityParamId == InvalidParamIndex)
+        // velocity or movement direction are necessary for movement
+        if (m_velocityParamId == InvalidParamIndex && m_movementDirectionParamId == InvalidParamIndex)
         {
             m_velocityParamId = m_animationGraph->FindParameterIndex(GetVelocityParamName().c_str());
+            m_movementDirectionParamId = m_animationGraph->FindParameterIndex(GetMovementDirectionParamName().c_str());
+            m_movementSpeedParamId = m_animationGraph->FindParameterIndex(GetMovementSpeedParamName().c_str());
             m_aimTargetParamId = m_animationGraph->FindParameterIndex(GetAimTargetParamName().c_str());
             m_crouchParamId = m_animationGraph->FindParameterIndex(GetCrouchParamName().c_str());
             m_aimingParamId = m_animationGraph->FindParameterIndex(GetAimingParamName().c_str());
@@ -112,35 +115,49 @@ namespace MultiplayerSample
             m_deathParamId = m_animationGraph->FindParameterIndex(GetDeathParamName().c_str());
         }
 
-        if (m_velocityParamId != InvalidParamIndex)
         {
+            // velocity and direction/speed based animations
+
             // base the anim on the player's generated velocity, not velocity from external sources
-            const AZ::Vector3 velocity = GetNetworkPlayerMovementComponent()->GetSelfGeneratedVelocity();
+            const AZ::Transform worldTm = GetEntity()->GetTransform()->GetWorldTM();
             const float maxSpeed = GetNetworkPlayerMovementComponent()->GetSprintSpeed();
+            AZ::Vector3 velocity = GetNetworkPlayerMovementComponent()->GetSelfGeneratedVelocity();
+            AZ::Vector2 velocity2d = AZ::Vector2(velocity.GetX(), velocity.GetY());
 
             if (GetVelocityIsLocal())
             {
-                // animgraph expects velocity relative to player
-                const AZ::Transform worldTm = GetEntity()->GetTransform()->GetWorldTM();
-                const AZ::Vector3 localRelativeVelocity = worldTm.GetInverse().TransformVector(velocity);
-                const AZ::Vector2 localRelativeVelocity2d = AZ::Vector2(localRelativeVelocity.GetX(), localRelativeVelocity.GetY());
+                velocity = worldTm.GetInverse().TransformVector(velocity);
+                velocity2d = AZ::Vector2(velocity.GetX(), velocity.GetY());
+            }
+
+            const float speed = velocity2d.GetLength() / maxSpeed;
+
+            if (m_velocityParamId != InvalidParamIndex)
+            {
                 const bool aiming = GetActiveAnimStates().GetBit(aznumeric_cast<uint32_t>(CharacterAnimState::Aiming));
                 if(GetTurningEnabled() && !aiming)
                 { 
-                    const float speed = localRelativeVelocity2d.GetLength() / maxSpeed;
-                    const float turnAmount = localRelativeVelocity2d.GetX();
+                    const float turnAmount = velocity2d.GetX();
                     m_animationGraph->SetParameterVector2(m_velocityParamId, AZ::Vector2(turnAmount, speed));
                 }
                 else
                 {
-                    m_animationGraph->SetParameterVector2(m_velocityParamId, localRelativeVelocity2d / maxSpeed);
+                    m_animationGraph->SetParameterVector2(m_velocityParamId, velocity2d / maxSpeed);
                 }
             }
-            else
-            { 
-                // animgraph expects velocity relative to world
-                const AZ::Vector2 velocity2d = AZ::Vector2(velocity.GetX(), velocity.GetY());
-                m_animationGraph->SetParameterVector2(m_velocityParamId, velocity2d / maxSpeed);
+            else if (m_movementDirectionParamId != InvalidParamIndex && m_movementSpeedParamId != InvalidParamIndex)
+            {
+                if (speed != 0.f)
+                {
+                    const AZ::Vector3 movementDirection = velocity.GetNormalized();
+                    m_animationGraph->SetParameterVector2(m_movementDirectionParamId, AZ::Vector2(movementDirection.GetX(), movementDirection.GetY()));
+                }
+                else
+                {
+                    const AZ::Vector3 forward = worldTm.GetBasisY();
+                    m_animationGraph->SetParameterVector2(m_movementDirectionParamId, AZ::Vector2(forward.GetX(), forward.GetY()));
+                }
+                m_animationGraph->SetParameterFloat(m_movementSpeedParamId, speed);
             }
         }
 
@@ -151,7 +168,11 @@ namespace MultiplayerSample
             const AZ::Transform worldTm = GetEntity()->GetTransform()->GetWorldTM();
             // TODO: This should probably be a physx raycast out to some maxDistance
             const AZ::Vector3 fwd = AZ::Vector3::CreateAxisY();
-            const AZ::Vector3 aimTarget = worldTm.GetTranslation() + aimRotation.TransformVector(fwd * 5.0f);
+            const AZ::Vector3 up = AZ::Vector3::CreateAxisZ();
+            AZ::Vector3 baseCameraOffset;
+            AZ::Interface<AZ::IConsole>::Get()->GetCvarValue("cl_cameraOffset", baseCameraOffset);
+            const AZ::Vector3 cameraOffset = aimRotation.TransformVector(baseCameraOffset);
+            const AZ::Vector3 aimTarget = worldTm.GetTranslation() + cameraOffset + aimRotation.TransformVector(fwd * 5.0f);
             m_animationGraph->SetParameterVector3(m_aimTargetParamId, aimTarget);
         }
 

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.h
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.h
@@ -71,6 +71,8 @@ namespace MultiplayerSample
         EMotionFX::Integration::AnimGraphComponentRequests* m_animationGraph = nullptr;
 
         // Hardcoded parameters, be nice if this was flexible and configurable from within the editor
+        size_t m_movementDirectionParamId = InvalidParamIndex;
+        size_t m_movementSpeedParamId = InvalidParamIndex;
         size_t m_velocityParamId = InvalidParamIndex;
         size_t m_aimTargetParamId = InvalidParamIndex;
         size_t m_crouchParamId = InvalidParamIndex;

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -150,19 +150,14 @@ namespace MultiplayerSample
 
         bool onGround = true;
         PhysX::CharacterGameplayRequestBus::EventResult(onGround, GetEntityId(), &PhysX::CharacterGameplayRequestBus::Events::IsOnGround);
-        if (onGround)
-        {
-            if (m_wasOnGround)
-            {
-                // the Landing anim state will automatically turn off
-                GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit( 
-                    aznumeric_cast<uint32_t>(CharacterAnimState::Landing), true);
-            }
 
-            GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
-                aznumeric_cast<uint32_t>(CharacterAnimState::Jumping), playerInput->m_jump);
-        }
+        // the Landing anim state will automatically turn off
+        GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit( 
+            aznumeric_cast<uint32_t>(CharacterAnimState::Landing), onGround && !m_wasOnGround);
 
+        // always set the jump state or you might get ghost jump animations
+        GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
+            aznumeric_cast<uint32_t>(CharacterAnimState::Jumping), playerInput->m_jump);
 
         // Update orientation
         AZ::Vector3 aimAngles = GetNetworkSimplePlayerCameraComponentController()->GetAimAngles();
@@ -183,7 +178,7 @@ namespace MultiplayerSample
 
         // if we're not moving down on a platform and have a negative velocity we're falling
         GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
-            aznumeric_cast<uint32_t>(CharacterAnimState::Falling), !onGround && absoluteVelocity.GetZ() < 0.f);
+            aznumeric_cast<uint32_t>(CharacterAnimState::Falling), !onGround && !m_wasOnGround && absoluteVelocity.GetZ() < 0.f);
 
         GetNetworkCharacterComponentController()->TryMoveWithVelocity(absoluteVelocity, deltaTime);
 

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -357,6 +357,15 @@ namespace MultiplayerSample
         // Inputs for your own component always exist
         NetworkWeaponsComponentNetworkInput* weaponInput = input.FindComponentInput<NetworkWeaponsComponentNetworkInput>();
 
+        // draw weapon automatically if firing
+        // use simple debounce for weapon draw to prevent multiple inputs between frames 
+        // TODO add cooldown timer
+        if (m_weaponDrawnChanged || (m_weaponFiring.AnySet() && !m_weaponDrawn))
+        {
+            m_weaponDrawn = !m_weaponDrawn;
+            m_weaponDrawnChanged = false;
+        }
+
         weaponInput->m_draw = m_weaponDrawn;
         weaponInput->m_firing = m_weaponFiring;
 
@@ -522,7 +531,7 @@ namespace MultiplayerSample
         }
         else if (*inputId == DrawEventId)
         {
-            m_weaponDrawn = !m_weaponDrawn;
+            m_weaponDrawnChanged = true;
         }
         else if (*inputId == FirePrimaryEventId)
         {

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.h
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.h
@@ -121,7 +121,8 @@ namespace MultiplayerSample
         // This means these values can and will migrate between hosts (and lose any stored state)
         // We will need to consider moving these values to Authority to Server network properties if the design doesn't change
         bool m_aiEnabled = false;
-        bool m_weaponDrawn = false;
+        bool m_weaponDrawn = true;
+        bool m_weaponDrawnChanged = false;
         WeaponActivationBitset m_weaponFiring;
     };
 }

--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -10669,7 +10669,7 @@
                     "Id": 7092071161962745685,
                     "Controller": {
                         "Configuration": {
-                            "EditorEntityId": 7870862829198950644
+                            "EditorEntityId": 9372934375852764365
                         }
                     }
                 },

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -133,6 +133,7 @@
                                 {}
                             ]
                         },
+                        "MaximumSlopeAngle": 45.0,
                         "StepHeight": 0.30000001192092896,
                         "ApplyMoveOnPhysicsTick": false,
                         "SlopeBehaviour": 1,

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -96,15 +96,15 @@
                     "Id": 11996978980717063697,
                     "m_template": {
                         "$type": "MultiplayerSample::NetworkAnimationComponent",
-                        "VelocityParamName": "movement_direction",
-                        "TurningEnabled": true,
-                        "AimTargetParamName": "target_position",
-                        "CrouchParamName": "crouch",
+                        "MovementDirectionParamName": "movement_direction",
+                        "MovementSpeedParamName": "movement_speed",
+                        "AimTargetParamName": "aim_target",
+                        "CrouchParamName": "crouching",
                         "AimingParamName": "aiming",
-                        "ShootParamName": "shoot",
-                        "JumpParamName": "jump",
-                        "FallParamName": "fall",
-                        "LandParamName": "land",
+                        "ShootParamName": "attacking",
+                        "JumpParamName": "jumping",
+                        "FallParamName": "falling",
+                        "LandParamName": "landing",
                         "HitParamName": "hit",
                         "DeathParamName": "death_state_index"
                     }
@@ -348,121 +348,59 @@
                     "Id": 4186588317358117667,
                     "AnimGraphAsset": {
                         "assetId": {
-                            "guid": "{46F677B6-0C57-50DE-BA38-2CC3079FDFC9}"
+                            "guid": "{BC61EACA-A8E6-5436-AE96-EF52288EB574}"
                         },
-                        "assetHint": "burt/humanoidcharacter.animgraph"
+                        "assetHint": "mixamo/ybot/ybot.animgraph"
                     },
                     "MotionSetAsset": {
                         "assetId": {
-                            "guid": "{0FA6D069-A122-57F5-BF54-A66AC8BE58A5}"
+                            "guid": "{A703856B-7290-5458-B7D8-7589EBD4F538}"
                         },
-                        "assetHint": "burt/burt.motionset"
+                        "assetHint": "mixamo/ybot/ybot.motionset"
                     },
-                    "ActiveMotionSetName": "BURTMotionSet",
+                    "ActiveMotionSetName": "YBotMotionSet",
                     "ParameterDefaults": {
                         "Parameters": [
                             {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 958518102,
-                                "name": "desired_angle"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 182703473,
-                                "name": "slope_angle"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 2155279128,
-                                "name": "crouch"
-                            },
-                            {
                                 "$type": "AzFramework::ScriptPropertyBoolean",
                                 "id": 1084884419,
-                                "name": "aiming"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 1883569342,
-                                "name": "shoot"
+                                "name": "aiming",
+                                "value": true
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 1720552084,
-                                "name": "lateral_adjustment",
-                                "value": 0.03500000014901161
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 819414243,
-                                "name": "height_adjustment",
-                                "value": -0.05000000074505806
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 2672514538,
-                                "name": "forward_adjustment"
+                                "id": 4070320611,
+                                "name": "movement_speed"
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 2813527574,
-                                "name": "jump"
+                                "id": 2356543930,
+                                "name": "jumping"
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 4216381196,
-                                "name": "fall"
+                                "id": 60754182,
+                                "name": "attacking"
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 2818627032,
-                                "name": "land"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 2553848132,
-                                "name": "land_type_index"
+                                "id": 70061904,
+                                "name": "crouching"
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 1523721793,
-                                "name": "hit"
+                                "id": 4097764052,
+                                "name": "falling"
                             },
                             {
-                                "$type": "AzFramework::ScriptPropertyNumber",
-                                "id": 4154523292,
-                                "name": "hit_axis_index"
+                                "$type": "AzFramework::ScriptPropertyBoolean",
+                                "id": 4013608469,
+                                "name": "landing"
                             },
                             {
                                 "$type": "AzFramework::ScriptPropertyNumber",
                                 "id": 23391511,
                                 "name": "death_state_index"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 2469366193,
-                                "name": "adjust_hip",
-                                "value": true
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 671657505,
-                                "name": "lock_feet"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 3470154576,
-                                "name": "foot_ik_weight"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 1891303514,
-                                "name": "victory"
-                            },
-                            {
-                                "$type": "AzFramework::ScriptPropertyBoolean",
-                                "id": 420668671,
-                                "name": "game_entry"
                             }
                         ]
                     }
@@ -487,22 +425,13 @@
                     "Id": 5329091026602047821,
                     "ActorAsset": {
                         "assetId": {
-                            "guid": "{85A4DFBC-18C2-5D1B-8066-F82FBF31E794}",
-                            "subId": 526701631
+                            "guid": "{49D8DCD0-7383-5AC7-8A87-CE6267605407}",
+                            "subId": 196688939
                         },
                         "loadBehavior": "QueueLoad",
-                        "assetHint": "burt/burtactor.actor"
+                        "assetHint": "mixamo/ybot/ybot.actor"
                     },
                     "MaterialPerLOD": [
-                        {
-                            "AssetPath": "burt/burtactor.mtl"
-                        },
-                        {
-                            "AssetPath": "burt/burtactor.mtl"
-                        },
-                        {
-                            "AssetPath": "burt/burtactor.mtl"
-                        },
                         {
                             "AssetPath": "burt/burtactor.mtl"
                         }
@@ -603,8 +532,8 @@
                             }
                         ],
                         "FireBoneNames": [
-                            "RightShoulder",
-                            "RightShoulder"
+                            "mixamorig:RightHand",
+                            "mixamorig:RightHand"
                         ]
                     }
                 },

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -401,6 +401,21 @@
                                 "$type": "AzFramework::ScriptPropertyNumber",
                                 "id": 23391511,
                                 "name": "death_state_index"
+                            },
+                            {
+                                "$type": "AzFramework::ScriptPropertyNumber",
+                                "id": 3656193794,
+                                "name": "hit_direction_index"
+                            },
+                            {
+                                "$type": "AzFramework::ScriptPropertyBoolean",
+                                "id": 713582873,
+                                "name": "stunned"
+                            },
+                            {
+                                "$type": "AzFramework::ScriptPropertyBoolean",
+                                "id": 1523721793,
+                                "name": "hit"
                             }
                         ]
                     }


### PR DESCRIPTION
NOTE: This cannot be merged until the asset PR is merged https://github.com/o3de/o3de-multiplayersample-assets/pull/46

Switches the player character to YBot
- fixes weapon draw debounce issue - draw weapon input was getting called twice per frame for no apparent reason.
- weapon now defaults to drawn

Known issues:
- that second jump anim bug is back
- aim motion is not smooth 
- aim target is off due to a change in how the camera offset is handled  - will fix this after my related PR is approved https://github.com/aws-lumberyard-dev/o3de-multiplayersample/pull/56