### PR TITLE
NetworklWeaponComponent: Fix compilation issue with AZ::Plane and minor code fixes

### DIFF
--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -28,7 +28,8 @@ namespace MultiplayerSample
     AZ_CVAR(float, sv_WeaponsImpulseScalar, 750.0f, nullptr, AZ::ConsoleFunctorFlags::Null, "A fudge factor for imparting impulses on rigid bodies due to weapon hits");
     AZ_CVAR(float, sv_WeaponsStartPositionClampRange, 1.f, nullptr, AZ::ConsoleFunctorFlags::Null, "A fudge factor between the where the client and server say a shot started");
     AZ_CVAR(float, sv_WeaponsDotClamp, 0.35f, nullptr, AZ::ConsoleFunctorFlags::Null, "Acceptable dot product range for a shot between the camera raycast and weapon raycast.");
-    void NetworkWeaponsComponent::NetworkWeaponsComponent::Reflect(AZ::ReflectContext* context)
+
+	void NetworkWeaponsComponent::NetworkWeaponsComponent::Reflect(AZ::ReflectContext* context)
     {
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
@@ -176,11 +177,9 @@ namespace MultiplayerSample
 
         m_onWeaponPredictHitEvent.Signal(hitInfo);
 
-        for (uint32_t i = 0; i < hitInfo.m_hitEvent.m_hitEntities.size(); ++i)
+        for (const auto& hitEntity : hitInfo.m_hitEvent.m_hitEntities)
         {
-            const HitEntity& hitEntity = hitInfo.m_hitEvent.m_hitEntities[i];
-
-            if (cl_WeaponsDrawDebug && m_debugDraw)
+	        if (cl_WeaponsDrawDebug && m_debugDraw)
             {
                 m_debugDraw->DrawSphereAtLocation
                 (
@@ -247,11 +246,9 @@ namespace MultiplayerSample
         // If we're a simulated weapon, or if the weapon is not predictive, then issue material hit effects since the predicted callback above will not get triggered
         [[maybe_unused]] bool shouldIssueMaterialEffects = !HasController() || !hitInfo.m_weapon.GetParams().m_locallyPredicted;
 
-        for (uint32_t i = 0; i < hitInfo.m_hitEvent.m_hitEntities.size(); ++i)
+        for (const auto& hitEntity : hitInfo.m_hitEvent.m_hitEntities)
         {
-            const HitEntity& hitEntity = hitInfo.m_hitEvent.m_hitEntities[i];
-
-            if (cl_WeaponsDrawDebug && m_debugDraw)
+	        if (cl_WeaponsDrawDebug && m_debugDraw)
             {
                 m_debugDraw->DrawSphereAtLocation
                 (
@@ -297,7 +294,7 @@ namespace MultiplayerSample
 
         while (weaponState.m_activationCount != value)
         {
-            const bool validateActivations = false;
+            constexpr bool validateActivations = false;
             ActivateWeaponWithParams(aznumeric_cast<WeaponIndex>(index), weaponState, fireParams, validateActivations);
         }
     }
@@ -312,7 +309,7 @@ namespace MultiplayerSample
 
     void NetworkWeaponsComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        NetworkAiComponent* networkAiComponent = GetParent().GetNetworkAiComponent();
+	    const NetworkAiComponent* networkAiComponent = GetParent().GetNetworkAiComponent();
         m_aiEnabled = (networkAiComponent != nullptr) ? networkAiComponent->GetEnabled() : false;
         if (m_aiEnabled)
         {
@@ -349,7 +346,7 @@ namespace MultiplayerSample
 
     AZ::Vector3 NetworkWeaponsComponent::GetCurrentShotStartPosition()
     {
-        const uint32_t weaponIndexInt = 0;
+        constexpr uint32_t weaponIndexInt = 0;
         const char* fireBoneName = GetFireBoneNames(weaponIndexInt).c_str();
         const int32_t boneIdx = GetNetworkAnimationComponent()->GetBoneIdByName(fireBoneName);
 
@@ -385,7 +382,7 @@ namespace MultiplayerSample
         weaponInput->m_firing = m_weaponFiring;
 
         // All weapon indices point to the same bone so only send one instance
-        const uint32_t weaponIndexInt = 0;
+        constexpr uint32_t weaponIndexInt = 0;
         if (weaponInput->m_firing.GetBit(weaponIndexInt))
         {
             weaponInput->m_shotStartPosition = GetParent().GetCurrentShotStartPosition();
@@ -451,10 +448,9 @@ namespace MultiplayerSample
                         physicsRayRequest.m_queryType = AzPhysics::SceneQuery::QueryType::StaticAndDynamic;
                         physicsRayRequest.m_reportMultipleHits = true;
 
-                        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &physicsRayRequest);
-                        if (result)
+                        if (AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &physicsRayRequest))
                         {
-                            for (AzPhysics::SceneQueryHit hit : result.m_hits)
+                            for (const AzPhysics::SceneQueryHit& hit : result.m_hits)
                             {
                                 // Set target to first found intersect within dot tolerance, if any
                                 AZ::Vector3 targetDirection = hit.m_position - weaponInput->m_shotStartPosition;

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -29,7 +29,7 @@ namespace MultiplayerSample
     AZ_CVAR(float, sv_WeaponsStartPositionClampRange, 1.f, nullptr, AZ::ConsoleFunctorFlags::Null, "A fudge factor between the where the client and server say a shot started");
     AZ_CVAR(float, sv_WeaponsDotClamp, 0.35f, nullptr, AZ::ConsoleFunctorFlags::Null, "Acceptable dot product range for a shot between the camera raycast and weapon raycast.");
 
-	void NetworkWeaponsComponent::NetworkWeaponsComponent::Reflect(AZ::ReflectContext* context)
+    void NetworkWeaponsComponent::NetworkWeaponsComponent::Reflect(AZ::ReflectContext* context)
     {
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
@@ -309,7 +309,7 @@ namespace MultiplayerSample
 
     void NetworkWeaponsComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-	    const NetworkAiComponent* networkAiComponent = GetParent().GetNetworkAiComponent();
+        const NetworkAiComponent* networkAiComponent = GetParent().GetNetworkAiComponent();
         m_aiEnabled = (networkAiComponent != nullptr) ? networkAiComponent->GetEnabled() : false;
         if (m_aiEnabled)
         {

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+#include <AzCore/Math/Plane.h>
 #include <Source/Components/NetworkWeaponsComponent.h>
 
 #include <Source/Components/NetworkAiComponent.h>


### PR DESCRIPTION
Fix for AZ::Plane errors on latest with unity builds:
```
  NvCloth.Editor.vcxproj -> E:\dev\o3de\aws-multiplayersample\build\windows_vs2019\bin\profile\NvCloth.Editor.Gem.dll
E:/dev/o3de/aws-multiplayersample/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp(433,27): error C2039: 'Plane': is not a member of 'AZ' [E:\dev\o3de\aws-multiplayersam ple\build\windows_vs2019\External\aws-multiplayersample-3e21c273\Gem\Code\MultiplayerSample.Static.vcxproj]
                  const AZ::Plane weaponPlane = AZ::Plane::CreateFromNormalAndPoint(cameraTransform.GetBasisY(), weaponInput->m_shotStartPosition);
```

Also contains:
* const expr warning fixes
* Move candidate to const ref in iteration
* Compact code to use more modern style c++ iteration

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>