### PR TITLE
Fix crash when no spawners found

### DIFF
--- a/Gem/Code/Source/Components/NetworkStressTestComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkStressTestComponent.cpp
@@ -179,6 +179,12 @@ namespace MultiplayerSample
             entityItem.GetNetBindComponent()->EnablePlayerHostAutonomy(true);
         }
 
+        if (entityList.empty())
+        {
+            AZ_Error("NetworkStressTestComponentController", false, "No AI entity to spawn");
+            return;
+        }
+
         Multiplayer::NetworkEntityHandle createdEntity = entityList[0];
         // Drive inputs from AI instead of user inputs and disable camera following
         NetworkAiComponentController* networkAiController = createdEntity.FindController<NetworkAiComponentController>();


### PR DESCRIPTION
Code reads first element but due to issues with local asset cache no spawners are found so local build would crash constantly on check. With check can join and connect local clients without issue.

Add naive safety guard to prevent crash. Looking for suggestions how to make messaging useful.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>