### PR TITLE
Fix input spam, update levels

### DIFF
--- a/CubeMapCaptures/Alpha_Diffuse__0579A8D6-B301-48D4-9D21-7B8E2509594E__ibldiffusecm.dds
+++ b/CubeMapCaptures/Alpha_Diffuse__0579A8D6-B301-48D4-9D21-7B8E2509594E__ibldiffusecm.dds
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8218e79dd2aee44a9a36e793eea09639946aef935dd5b68c325d914a7e92e69
+oid sha256:1a18d826e8b1be419f35db2ba64aa0c1ac76e3fe897456c64666c1dd76544340
 size 50331796

--- a/CubeMapCaptures/Alpha_Specular__2E417A90-191C-4583-AA62-D6C9C9B61D1E__iblspecularcm256.dds
+++ b/CubeMapCaptures/Alpha_Specular__2E417A90-191C-4583-AA62-D6C9C9B61D1E__iblspecularcm256.dds
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b1884f3b7979594f31870db1d4a0926b7b87d68f9638b8e1d00607af1b18d2a
+oid sha256:f936643c54c19f973b18ad97bf7cb011bdd1811e85cdc176dc19f567f3f290db
 size 50331796

--- a/Levels/Alpha/Alpha.prefab
+++ b/Levels/Alpha/Alpha.prefab
@@ -33,7 +33,9 @@
                     "Instance_[872918975093123]/ContainerEntity",
                     "Entity_[5674883717507]",
                     "Entity_[872897500256643]",
-                    "Instance_[80137830564903]/ContainerEntity"
+                    "Instance_[80137830564903]/ContainerEntity",
+                    "Instance_[51914644903660]/ContainerEntity",
+                    "Instance_[43906299149777]/ContainerEntity"
                 ]
             },
             "Component_[15230859088967841193]": {
@@ -25238,7 +25240,8 @@
                                     "subId": 2000
                                 },
                                 "assetHint": "cubemapcaptures/alpha_specular__2e417a90-191c-4583-aa62-d6c9c9b61d1e__iblspecularcm256.dds.streamingimage"
-                            }
+                            },
+                            "exposure": -0.5
                         }
                     },
                     "diffuseImageAsset": {
@@ -25254,7 +25257,8 @@
                             "subId": 2000
                         },
                         "assetHint": "cubemapcaptures/alpha_specular__2e417a90-191c-4583-aa62-d6c9c9b61d1e__iblspecularcm256.dds.streamingimage"
-                    }
+                    },
+                    "exposure": -0.5
                 },
                 "Component_[5138134953073834077]": {
                     "$type": "EditorVisibilityComponent",
@@ -25271,7 +25275,8 @@
                                     "subId": 2000
                                 },
                                 "assetHint": "skies/evening_horizon_iblskyboxcm_iblspecular.exr.streamingimage"
-                            }
+                            },
+                            "Exposure": -2.700000047683716
                         }
                     }
                 },
@@ -27152,6 +27157,31 @@
                 }
             ]
         },
+        "Instance_[43906299149777]": {
+            "Source": "Prefabs/GamePlay_Effects.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[13490474510842214515]/Parent Entity",
+                    "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[13490474510842214515]/Transform Data/Translate/0",
+                    "value": -59.073909759521484
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[13490474510842214515]/Transform Data/Translate/1",
+                    "value": 42.069480895996094
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[13490474510842214515]/Transform Data/Translate/2",
+                    "value": -4.143481254577637
+                }
+            ]
+        },
         "Instance_[43960222194051]": {
             "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_A.prefab",
             "Patches": [
@@ -28044,6 +28074,31 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11388605022631206776]/Transform Data/Rotate/2",
                     "value": 180.0
+                }
+            ]
+        },
+        "Instance_[51914644903660]": {
+            "Source": "Prefabs/MatchController.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[16882190328477997960]/Parent Entity",
+                    "value": "../Entity_[1146574390643]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[16882190328477997960]/Transform Data/Translate/0",
+                    "value": 2.871580123901367
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[16882190328477997960]/Transform Data/Translate/1",
+                    "value": -41.57832336425781
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[16882190328477997960]/Transform Data/Translate/2",
+                    "value": 5.555325031280518
                 }
             ]
         },
@@ -29143,7 +29198,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16237068544565649519]/Transform Data/Translate/2",
-                    "value": -3.299999952316284
+                    "value": -3.240565776824951
                 }
             ]
         },

--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -10687,7 +10687,7 @@
         },
         "Entity_[830977005898]": {
             "Id": "Entity_[830977005898]",
-            "Name": "Camera",
+            "Name": "Camera and Input",
             "Components": {
                 "Component_[13707688659030262739]": {
                     "$type": "EditorEntityIconComponent",
@@ -10735,6 +10735,19 @@
                         ]
                     }
                 },
+                "Component_[299241743554369776]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 299241743554369776,
+                    "m_template": {
+                        "$type": "InputConfigurationComponent",
+                        "Input Event Bindings": {
+                            "assetId": {
+                                "guid": "{C67E0526-85F2-525B-A44B-04855474A5BE}"
+                            },
+                            "assetHint": "inputbindings/player.inputbindings"
+                        }
+                    }
+                },
                 "Component_[3655999494444134160]": {
                     "$type": "GenericComponentWrapper",
                     "Id": 3655999494444134160,
@@ -10759,7 +10772,7 @@
                     "Id": 7092071161962745685,
                     "Controller": {
                         "Configuration": {
-                            "EditorEntityId": 9372934375852764365
+                            "EditorEntityId": 989740997263671176
                         }
                     }
                 },

--- a/Prefabs/GamePlay_Effects.prefab
+++ b/Prefabs/GamePlay_Effects.prefab
@@ -1,0 +1,158 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "GamePlay_Effects",
+        "Components": {
+            "Component_[12450055130148559371]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12450055130148559371
+            },
+            "Component_[13490474510842214515]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 13490474510842214515,
+                "Parent Entity": ""
+            },
+            "Component_[1504729941609681648]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 1504729941609681648
+            },
+            "Component_[15482869980983967676]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 15482869980983967676
+            },
+            "Component_[16871230422689996014]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16871230422689996014
+            },
+            "Component_[2242806845704960273]": {
+                "$type": "EditorLockComponent",
+                "Id": 2242806845704960273
+            },
+            "Component_[2511009772429746619]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 2511009772429746619,
+                "Child Entity Order": [
+                    "Entity_[39735885905361]"
+                ]
+            },
+            "Component_[4099753608611289960]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 4099753608611289960
+            },
+            "Component_[4372557423451646264]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4372557423451646264
+            },
+            "Component_[9463531765175646720]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 9463531765175646720
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[39735885905361]": {
+            "Id": "Entity_[39735885905361]",
+            "Name": "GamePlay Effects",
+            "Components": {
+                "Component_[11946705441174808443]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11946705441174808443
+                },
+                "Component_[12472505337896015496]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12472505337896015496
+                },
+                "Component_[12557627627480150856]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12557627627480150856,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[13295483437782755113]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 13295483437782755113,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[1504635443841809763]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1504635443841809763,
+                    "m_template": {
+                        "$type": "NetworkPrefabSpawnerComponent",
+                        "Default Prefab": {
+                            "assetId": {
+                                "guid": "{35EE7939-1A13-5B58-B05C-5D90DB3ACC0E}",
+                                "subId": 2091499493
+                            },
+                            "assetHint": "prefabs/sound_effect.spawnable"
+                        }
+                    }
+                },
+                "Component_[16370588755011357885]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16370588755011357885,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[16666566038828336824]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16666566038828336824
+                },
+                "Component_[4614452708224633330]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4614452708224633330
+                },
+                "Component_[5218063406307720170]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5218063406307720170
+                },
+                "Component_[6305603003699945145]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6305603003699945145
+                },
+                "Component_[8106850883560113265]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 8106850883560113265,
+                    "m_template": {
+                        "$type": "MultiplayerSample::GameplayEffectsComponent",
+                        "GemPickup": "Play_Gem_Pickup",
+                        "RoundStart": "Play_Round_Begin",
+                        "RoundEnd": "Play_Round_End",
+                        "LaserPistolImpact": "Play_Laser_Gun_Impact",
+                        "EnergyBallTrapImpact": "Play_Laser_Gun_Impact"
+                    }
+                },
+                "Component_[8376277465513176068]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8376277465513176068
+                },
+                "Component_[8837169591982663765]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8837169591982663765,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 16370588755011357885
+                        },
+                        {
+                            "ComponentId": 1504635443841809763,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12557627627480150856,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13295483437782755113,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 8106850883560113265,
+                            "SortIndex": 4
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/Prefabs/MatchController.prefab
+++ b/Prefabs/MatchController.prefab
@@ -1,0 +1,2209 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "MatchController",
+        "Components": {
+            "Component_[1055115967866462048]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 1055115967866462048
+            },
+            "Component_[11164568530150112052]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 11164568530150112052
+            },
+            "Component_[11487115235298196061]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 11487115235298196061
+            },
+            "Component_[11854989396622833674]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 11854989396622833674
+            },
+            "Component_[16376507811155694849]": {
+                "$type": "EditorLockComponent",
+                "Id": 16376507811155694849
+            },
+            "Component_[16882190328477997960]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 16882190328477997960,
+                "Parent Entity": ""
+            },
+            "Component_[17677888273479354473]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 17677888273479354473
+            },
+            "Component_[5933063119998042372]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 5933063119998042372
+            },
+            "Component_[7371433350230258710]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 7371433350230258710
+            },
+            "Component_[7687618193783742482]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7687618193783742482,
+                "Child Entity Order": [
+                    "Entity_[47306144995052]"
+                ]
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[43932068953553]": {
+            "Id": "Entity_[43932068953553]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47297555060460]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[43936363920849]": {
+            "Id": "Entity_[43936363920849]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47263195322092]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[43949248822737]": {
+            "Id": "Entity_[43949248822737]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47254605387500]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[43962133724625]": {
+            "Id": "Entity_[43962133724625]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47280375191276]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[43975018626513]": {
+            "Id": "Entity_[43975018626513]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47301850027756]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.800000011920929,
+                                                    0.6987106204032898,
+                                                    0.06086823716759682,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44756702674385]": {
+            "Id": "Entity_[44756702674385]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47271785256684]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.800000011920929,
+                                                    0.6987106204032898,
+                                                    0.06086823716759682,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44773882543569]": {
+            "Id": "Entity_[44773882543569]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47246015452908]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.800000011920929,
+                                                    0.6987106204032898,
+                                                    0.06086823716759682,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44791062412753]": {
+            "Id": "Entity_[44791062412753]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47250310420204]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.800000011920929,
+                                                    0.6987106204032898,
+                                                    0.06086823716759682,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44808242281937]": {
+            "Id": "Entity_[44808242281937]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47237425518316]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.8381475806236267,
+                                                    0.011490043252706528,
+                                                    0.011490043252706528,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44829717118417]": {
+            "Id": "Entity_[44829717118417]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47241720485612]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.8381475806236267,
+                                                    0.011490043252706528,
+                                                    0.011490043252706528,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44846896987601]": {
+            "Id": "Entity_[44846896987601]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47267490289388]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.8381475806236267,
+                                                    0.011490043252706528,
+                                                    0.011490043252706528,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[44864076856785]": {
+            "Id": "Entity_[44864076856785]",
+            "Name": "EditorMesh",
+            "Components": {
+                "Component_[10381832473673573979]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10381832473673573979
+                },
+                "Component_[12305480926239291563]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12305480926239291563
+                },
+                "Component_[12337837433691081794]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 12337837433691081794,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{6F60A708-58B3-5A78-9BD2-FAA3FE9ED85B}",
+                                    "subId": 273712816
+                                },
+                                "assetHint": "objects/gem.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[12526063980673560172]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12526063980673560172,
+                    "Parent Entity": "Entity_[47258900354796]",
+                    "Transform Data": {
+                        "UniformScale": 0.5
+                    }
+                },
+                "Component_[13352265952059361758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13352265952059361758,
+                    "IsEditorOnly": true
+                },
+                "Component_[17546892156080361386]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 17546892156080361386,
+                    "Controller": {
+                        "Configuration": {
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 1890610506
+                                    },
+                                    "Value": {
+                                        "PropertyOverrides": {
+                                            "baseColor.color": {
+                                                "$type": "Color",
+                                                "Value": [
+                                                    0.8381475806236267,
+                                                    0.011490043252706528,
+                                                    0.011490043252706528,
+                                                    1.0
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[2087251486508120258]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2087251486508120258
+                },
+                "Component_[546970229948265825]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 546970229948265825
+                },
+                "Component_[7217597316748744637]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7217597316748744637
+                },
+                "Component_[8183225851333848648]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8183225851333848648
+                },
+                "Component_[9919220163134607188]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9919220163134607188
+                }
+            }
+        },
+        "Entity_[47237425518316]": {
+            "Id": "Entity_[47237425518316]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47293260093164]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.4109153747558594,
+                            -1.3791980743408203,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44808242281937]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47241720485612]": {
+            "Id": "Entity_[47241720485612]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47293260093164]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.3705177307128906,
+                            0.8513317108154297,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44829717118417]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47246015452908]": {
+            "Id": "Entity_[47246015452908]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47276080223980]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.038158416748047,
+                            1.7487506866455078,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44773882543569]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47250310420204]": {
+            "Id": "Entity_[47250310420204]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47276080223980]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.9366178512573242,
+                            -1.998849868774414,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44791062412753]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47254605387500]": {
+            "Id": "Entity_[47254605387500]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47288965125868]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.8095998764038086,
+                            1.6657381057739258,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[43949248822737]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47258900354796]": {
+            "Id": "Entity_[47258900354796]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47293260093164]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.1717920303344727,
+                            -1.466756820678711,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44864076856785]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47263195322092]": {
+            "Id": "Entity_[47263195322092]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47288965125868]",
+                    "Transform Data": {
+                        "Translate": [
+                            1.8095998764038086,
+                            -1.9781389236450195,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[43936363920849]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47267490289388]": {
+            "Id": "Entity_[47267490289388]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47293260093164]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.1144886016845703,
+                            0.8288860321044922,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44846896987601]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47271785256684]": {
+            "Id": "Entity_[47271785256684]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47276080223980]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.6597814559936523,
+                            -1.8274497985839844,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[44756702674385]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47276080223980]": {
+            "Id": "Entity_[47276080223980]",
+            "Name": "Gold Gems",
+            "Components": {
+                "Component_[10367151128854293912]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10367151128854293912
+                },
+                "Component_[11786358053083061803]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11786358053083061803
+                },
+                "Component_[13748178433330710490]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13748178433330710490
+                },
+                "Component_[15106714839049108594]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15106714839049108594
+                },
+                "Component_[15444411588471441762]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15444411588471441762
+                },
+                "Component_[3155992983308286846]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3155992983308286846,
+                    "Child Entity Order": [
+                        "Entity_[47301850027756]",
+                        "Entity_[47271785256684]",
+                        "Entity_[47246015452908]",
+                        "Entity_[47250310420204]"
+                    ]
+                },
+                "Component_[5724957761008664969]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5724957761008664969
+                },
+                "Component_[7417238046417582513]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7417238046417582513,
+                    "Parent Entity": "Entity_[47284670158572]",
+                    "Transform Data": {
+                        "Translate": [
+                            10.825023651123047,
+                            -2.2692785263061523,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[743084232895681676]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 743084232895681676
+                }
+            }
+        },
+        "Entity_[47280375191276]": {
+            "Id": "Entity_[47280375191276]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47288965125868]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7867989540100098,
+                            1.3939218521118164,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[43962133724625]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47284670158572]": {
+            "Id": "Entity_[47284670158572]",
+            "Name": "Gem Spawns",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47306144995052]",
+                    "Transform Data": {
+                        "Translate": [
+                            -8.490331649780273,
+                            -4.103538513183594,
+                            0.24772119522094727
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[47288965125868]",
+                        "Entity_[47276080223980]",
+                        "Entity_[47293260093164]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47288965125868]": {
+            "Id": "Entity_[47288965125868]",
+            "Name": "Blue Gems",
+            "Components": {
+                "Component_[10520542514760359000]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10520542514760359000
+                },
+                "Component_[13705573339171950882]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13705573339171950882,
+                    "Parent Entity": "Entity_[47284670158572]",
+                    "Transform Data": {
+                        "Translate": [
+                            3.7724242210388184,
+                            -2.480555534362793,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[14273418305113140283]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14273418305113140283
+                },
+                "Component_[1442924958533446424]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1442924958533446424
+                },
+                "Component_[17906383532197735688]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17906383532197735688
+                },
+                "Component_[18248421548186182158]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18248421548186182158,
+                    "Child Entity Order": [
+                        "Entity_[47297555060460]",
+                        "Entity_[47263195322092]",
+                        "Entity_[47254605387500]",
+                        "Entity_[47280375191276]"
+                    ]
+                },
+                "Component_[6277972786675610669]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6277972786675610669
+                },
+                "Component_[6709679306597448613]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6709679306597448613
+                },
+                "Component_[750970520705058917]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 750970520705058917
+                }
+            }
+        },
+        "Entity_[47293260093164]": {
+            "Id": "Entity_[47293260093164]",
+            "Name": "Mixed Chance Gems",
+            "Components": {
+                "Component_[10638873794404425748]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10638873794404425748,
+                    "Parent Entity": "Entity_[47284670158572]",
+                    "Transform Data": {
+                        "Translate": [
+                            6.9643988609313965,
+                            -7.5573835372924805,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[13543309276499088395]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13543309276499088395,
+                    "Child Entity Order": [
+                        "Entity_[47237425518316]",
+                        "Entity_[47241720485612]",
+                        "Entity_[47267490289388]",
+                        "Entity_[47258900354796]"
+                    ]
+                },
+                "Component_[15081266204926756650]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15081266204926756650
+                },
+                "Component_[15832176722447303609]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15832176722447303609
+                },
+                "Component_[2529283720378254621]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2529283720378254621
+                },
+                "Component_[3865907779322185523]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3865907779322185523
+                },
+                "Component_[478119451776875111]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 478119451776875111
+                },
+                "Component_[4801967175474973825]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4801967175474973825
+                },
+                "Component_[6125586192346228741]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 6125586192346228741
+                }
+            }
+        },
+        "Entity_[47297555060460]": {
+            "Id": "Entity_[47297555060460]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Blue Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47288965125868]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.7867989540100098,
+                            -2.081862449645996,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[43932068953553]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47301850027756]": {
+            "Id": "Entity_[47301850027756]",
+            "Name": "Gem Spawn Point",
+            "Components": {
+                "Component_[14996001446518828486]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14996001446518828486
+                },
+                "Component_[17654780888628864406]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17654780888628864406
+                },
+                "Component_[258245540820059914]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 258245540820059914
+                },
+                "Component_[2631286670279943301]": {
+                    "$type": "EditorTagComponent",
+                    "Id": 2631286670279943301,
+                    "Tags": [
+                        "Gem Spawn",
+                        "Gold Gem"
+                    ]
+                },
+                "Component_[3159308103417765039]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3159308103417765039,
+                    "Parent Entity": "Entity_[47276080223980]",
+                    "Transform Data": {
+                        "Translate": [
+                            -1.4457902908325195,
+                            1.6961326599121094,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[5279813910516778661]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5279813910516778661
+                },
+                "Component_[6472368245188254069]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6472368245188254069
+                },
+                "Component_[7528012486995970018]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7528012486995970018
+                },
+                "Component_[8448193961756316732]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8448193961756316732
+                },
+                "Component_[9563005782360935820]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9563005782360935820,
+                    "Child Entity Order": [
+                        "Entity_[43975018626513]"
+                    ]
+                }
+            }
+        },
+        "Entity_[47306144995052]": {
+            "Id": "Entity_[47306144995052]",
+            "Name": "MatchController",
+            "Components": {
+                "Component_[10815511516873400869]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 10815511516873400869,
+                    "m_template": {
+                        "$type": "MultiplayerSample::GemSpawnerComponent",
+                        "GemSpawnables": [
+                            {
+                                "Tag": "Gold Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{878A68F4-3E7B-5418-BB80-96EEFA6574F3}",
+                                        "subId": 3800375621
+                                    },
+                                    "assetHint": "prefabs/gold_gem.spawnable"
+                                }
+                            },
+                            {
+                                "Tag": "Blue Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{CC18AC5B-59FC-5BC0-ABAC-1FD20DF3A6D0}",
+                                        "subId": 2978055772
+                                    },
+                                    "assetHint": "prefabs/blue_gem.spawnable"
+                                },
+                                "Score": 3
+                            },
+                            {
+                                "Tag": "Green Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{60CC9A11-93CF-50A1-B2FA-4DA2AAA23151}",
+                                        "subId": 2831178280
+                                    },
+                                    "assetHint": "prefabs/green_gem.spawnable"
+                                },
+                                "Score": 2
+                            },
+                            {
+                                "Tag": "Red Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{A63F9843-2632-521C-9A96-569BE4081FBD}",
+                                        "subId": 1199407584
+                                    },
+                                    "assetHint": "prefabs/red_gem.spawnable"
+                                },
+                                "Score": 4
+                            },
+                            {
+                                "Tag": "Diamond Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{EEBE82AD-4B06-517C-9036-2EF633DBDA7B}",
+                                        "subId": 4122414694
+                                    },
+                                    "assetHint": "prefabs/diamond_gem.spawnable"
+                                },
+                                "Score": 5
+                            }
+                        ],
+                        "SpawnTablesPerRound": [
+                            {},
+                            {
+                                "Gem Weights": [
+                                    {
+                                        "Gem Tag Type": "Gold Gem"
+                                    },
+                                    {
+                                        "Gem Tag Type": "Blue Gem",
+                                        "Gem Weight": 0.5
+                                    }
+                                ]
+                            }
+                        ],
+                        "GemSpawnTag": "Gem Spawn"
+                    }
+                },
+                "Component_[11044208504869032248]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 11044208504869032248,
+                    "m_template": {
+                        "$type": "MultiplayerSample::NetworkMatchComponent",
+                        "TotalRounds": 1
+                    }
+                },
+                "Component_[11582545100212439853]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11582545100212439853
+                },
+                "Component_[13299105916626157805]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 13299105916626157805,
+                    "m_template": {
+                        "$type": "NetworkPrefabSpawnerComponent"
+                    }
+                },
+                "Component_[14478429868711242326]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14478429868711242326,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5143246854913296527
+                        },
+                        {
+                            "ComponentId": 3709937876037180985,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 13299105916626157805,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16952898907599562589,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 18093579538353675715,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 17414909752872705959,
+                            "SortIndex": 5
+                        },
+                        {
+                            "ComponentId": 10815511516873400869,
+                            "SortIndex": 6
+                        },
+                        {
+                            "ComponentId": 18116832539607953979,
+                            "SortIndex": 7
+                        },
+                        {
+                            "ComponentId": 11044208504869032248,
+                            "SortIndex": 8
+                        },
+                        {
+                            "ComponentId": 17163718511096577681,
+                            "SortIndex": 9
+                        }
+                    ]
+                },
+                "Component_[16952898907599562589]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 16952898907599562589,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[17083415778652839230]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17083415778652839230
+                },
+                "Component_[17163718511096577681]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17163718511096577681,
+                    "m_template": {
+                        "$type": "MultiplayerSample::HUDComponent",
+                        "RoundNumberId": 8,
+                        "RoundTimerId": 4
+                    }
+                },
+                "Component_[17414909752872705959]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17414909752872705959,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[17500813252784751517]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17500813252784751517
+                },
+                "Component_[18093579538353675715]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 18093579538353675715,
+                    "m_template": {
+                        "$type": "MultiplayerSample::NetworkRandomComponent"
+                    }
+                },
+                "Component_[18116832539607953979]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 18116832539607953979,
+                    "m_template": {
+                        "$type": "MultiplayerSample::MatchPlayerCoinsComponent"
+                    }
+                },
+                "Component_[3709937876037180985]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 3709937876037180985,
+                    "m_template": {
+                        "$type": "UiCanvasAssetRefComponent",
+                        "CanvasAssetRef": {
+                            "AssetPath": "uicanvases/basichud.uicanvas"
+                        },
+                        "IsAutoLoad": true
+                    }
+                },
+                "Component_[5143246854913296527]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5143246854913296527,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[5932985006849230681]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5932985006849230681
+                },
+                "Component_[6432885729127046056]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6432885729127046056
+                },
+                "Component_[6533115235637337163]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6533115235637337163,
+                    "Child Entity Order": [
+                        "Entity_[47284670158572]"
+                    ]
+                },
+                "Component_[7686939683724604717]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7686939683724604717
+                }
+            }
+        }
+    }
+}

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -51,19 +51,6 @@
             "Id": "Entity_[1423682492746]",
             "Name": "Player",
             "Components": {
-                "Component_[10731928891422556040]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 10731928891422556040,
-                    "m_template": {
-                        "$type": "InputConfigurationComponent",
-                        "Input Event Bindings": {
-                            "assetId": {
-                                "guid": "{C67E0526-85F2-525B-A44B-04855474A5BE}"
-                            },
-                            "assetHint": "inputbindings/player.inputbindings"
-                        }
-                    }
-                },
                 "Component_[10752091759919038477]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10752091759919038477,
@@ -465,6 +452,11 @@
                         "SprintSpeed": 6.0,
                         "JumpVelocity": 8.0
                     }
+                },
+                "Component_[5984669395829237154]": {
+                    "$type": "EditorCommentComponent",
+                    "Id": 5984669395829237154,
+                    "Configuration": "Do not add an InputBinding component to this prefab, only add it to your level or load the bindings some other way.  Multiple InputBinding components will lead to input events getting sent per-component and cause input spam."
                 },
                 "Component_[6252367322126438780]": {
                     "$type": "GenericComponentWrapper",

--- a/Prefabs/Player_Camera.prefab
+++ b/Prefabs/Player_Camera.prefab
@@ -58,6 +58,19 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 13707688659030262739
                 },
+                "Component_[1385590164709555587]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 1385590164709555587,
+                    "m_template": {
+                        "$type": "InputConfigurationComponent",
+                        "Input Event Bindings": {
+                            "assetId": {
+                                "guid": "{C67E0526-85F2-525B-A44B-04855474A5BE}"
+                            },
+                            "assetHint": "inputbindings/player.inputbindings"
+                        }
+                    }
+                },
                 "Component_[14557570787500416175]": {
                     "$type": "AZ::Render::EditorBloomComponent",
                     "Id": 14557570787500416175,
@@ -133,7 +146,7 @@
                     "Id": 7092071161962745685,
                     "Controller": {
                         "Configuration": {
-                            "EditorEntityId": 1010066591619431053
+                            "EditorEntityId": 11054489293252630626
                         }
                     }
                 },

--- a/Prefabs/StressTestEntity.prefab
+++ b/Prefabs/StressTestEntity.prefab
@@ -1,0 +1,137 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "StressTestEntity",
+        "Components": {
+            "Component_[10044544960086186962]": {
+                "$type": "EditorLockComponent",
+                "Id": 10044544960086186962
+            },
+            "Component_[13238298805784396752]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 13238298805784396752
+            },
+            "Component_[16602504218496358039]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 16602504218496358039
+            },
+            "Component_[2759623355304920326]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 2759623355304920326
+            },
+            "Component_[3106986445862067621]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3106986445862067621
+            },
+            "Component_[3418903134259688067]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3418903134259688067
+            },
+            "Component_[3576772637035379920]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 3576772637035379920
+            },
+            "Component_[6007217445804973511]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 6007217445804973511,
+                "Parent Entity": ""
+            },
+            "Component_[8119607782923238855]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 8119607782923238855,
+                "Child Entity Order": [
+                    "Entity_[113740699129580]"
+                ]
+            },
+            "Component_[8636872437122949059]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 8636872437122949059
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[113740699129580]": {
+            "Id": "Entity_[113740699129580]",
+            "Name": "StressTestEntity",
+            "Components": {
+                "Component_[11071255408563586395]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11071255408563586395
+                },
+                "Component_[13137916724228702403]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13137916724228702403
+                },
+                "Component_[13587877359869569916]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13587877359869569916
+                },
+                "Component_[14015850877258941312]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14015850877258941312
+                },
+                "Component_[16224318489599771652]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16224318489599771652
+                },
+                "Component_[17036114540992779581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17036114540992779581
+                },
+                "Component_[17455045336231784718]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 17455045336231784718,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[2460158543297630222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 2460158543297630222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7256215421682667603
+                        },
+                        {
+                            "ComponentId": 509088171691650234,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7492029015899717881,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17455045336231784718,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4439287455987253256]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4439287455987253256
+                },
+                "Component_[509088171691650234]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 509088171691650234,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[7256215421682667603]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7256215421682667603,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[7492029015899717881]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7492029015899717881,
+                    "m_template": {
+                        "$type": "MultiplayerSample::NetworkStressTestComponent",
+                        "AutoSpawnIntervalMs": 1000,
+                        "MaxSpawns": 10
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix issue where mouse would lag when fps was low - this was due to all spawned characters having input binding components and each component would send input events so the local player was receiving input event spam.

Changes
1. removed input bindings component from player prefab
2. added input binding component to GamePlayTest and Alpha levels
3. minor changes to Alpha level skybox, audio, added match controller etc.
 
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>