### PR TITLE
Fix shader issues caused by undefined ObjectSrg

### DIFF
--- a/Materials/UVs.azsl
+++ b/Materials/UVs.azsl
@@ -7,7 +7,7 @@
  */
 
 #include <viewsrg.srgi>
-#include <Atom/RPI/ShaderResourceGroups/DefaultObjectSrg.azsli>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/PBR/ForwardPassSrg.azsli>
 


### PR DESCRIPTION
AP would fail on these three assets because of this error

```
12/15/2022 4:01 PM | ERROR | DXC: E:/dev/o3de/aws-multiplayersample/user/AssetProcessorTemp/JobTemp-oDHgVR/UVs.azsl.dx12.prepend:46:30: error: use of undeclared identifier 'ObjectSrg' from AssetBuilder
```

With change assets now process. Unsure if anything is actually using material at this point but it removes AP log spam for now.


Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>