### PR TITLE
Adjust atmos to avoid falling into planet

### DIFF
--- a/Levels/Alpha/Alpha.prefab
+++ b/Levels/Alpha/Alpha.prefab
@@ -24290,7 +24290,14 @@
                 "Component_[17794639845029481355]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17794639845029481355,
-                    "Parent Entity": "Entity_[959209163037059]"
+                    "Parent Entity": "Entity_[959209163037059]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            -300.0
+                        ]
+                    }
                 },
                 "Component_[17822647489610734478]": {
                     "$type": "EditorEntityIconComponent",


### PR DESCRIPTION
Jumping to bottom level will cause player to be in pitch dark state, this is because the atmos part of the skybox is too high and player has "fallen into the planet" from rendering POV.

Before change:
![Screen Shot 2022-12-21 at 3 38 19 PM (2)](https://user-images.githubusercontent.com/61438964/209024136-59f8ff18-6d78-476d-a4e2-5994cd203578.png)


Tweak down by 300 as best guess, with this change low level renders and player remains in level from rendering POV 

After change:
![Screen Shot 2022-12-21 at 3 48 27 PM (2)](https://user-images.githubusercontent.com/61438964/209024603-777c177b-4519-4fb0-a84d-ab31f9ea18db.png)

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>