### PR TITLE
Remove secondary EMFX snapshot call that can be invoked before anim graph is ready

### DIFF
--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -101,8 +101,8 @@ namespace MultiplayerSample
 
         if (m_networkRequests->HasSnapshot() == false)
         {
-            constexpr bool isAuthoritative = true;
-            m_networkRequests->CreateSnapshot(isAuthoritative);
+            // AnimGraph is not ready, wait for OnAnimGraphInstanceCreated
+            return;
         }
 
         // velocity or movement direction are necessary for movement


### PR DESCRIPTION
Remove potential source of EMFX warnings if we try and snapshot before Anim Graph is ready.

Code will still create snapshot but in response to AnimGraphIsReady signal, see https://github.com/o3de/o3de/issues/14142 for details

## Testing
* Built on windows
* Ran game in editor and game plays as expected
* Need to test standalone client / server

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>