### PR TITLE
Fix Launcher release builds

### DIFF
--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -193,8 +193,8 @@ namespace MultiplayerSample
                 }
             }
 #endif
-        }
 #endif // AZ_RELEASE_BUILD
+        }
 
         if (m_crouchParamId != InvalidParamIndex)
         {


### PR DESCRIPTION
Fixes issue when running `cmake --build build\windows --target install --config release -- -m` where code fails to build for launchers in release due to missing '}'


Does not fix issues relating to missing registry files in release builds. For some reason no registry files are generated nor a registry folder (code expects there one to be at `\build\windows\bin\release\Registry` but its missing.

```
﻿﻿C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): warning MSB8064: Custom build for item "E:\dev\o3de\aws-multiplayersample\build\windows\CMakeFiles\
ea1275878c1555cf1de0b7246a7c76a4\Editor.stamp.rule" succeeded, but specified dependency "e:\dev\o3de\aws-multiplayersample\build\windows\bin\release\registry\cmake_dependencies.multiplayersample.editor.setreg" does not exist.
This may cause incremental build to work incorrectly. [E:\dev\o3de\aws-multiplayersample\build\windows\o3de\Code\Editor\Editor.vcxproj]
  qrc_resources.cpp
  unity_0_cxx.cxx
  Editor.vcxproj -> E:\dev\o3de\aws-multiplayersample\build\windows\bin\release\Editor.exe
  Building Custom Rule E:/dev/o3de/aws-multiplayersample/CMakeLists.txt
  -- Install configuration: "release"
  -- Generating E:/dev/o3de/aws-multiplayersample/install/bin/Windows/release/Default/Cache/pc/engine.pak from E:/dev/o3de/aws-multiplayersample/Cache/pc
  CMake Error at o3de/Registry/cmake_install.cmake:51 (file):
    file INSTALL cannot find
    "E:/dev/o3de/aws-multiplayersample/build/windows/bin/release/Registry": No
    such file or directory.
  Call Stack (most recent call first):
    o3de/cmake_install.cmake:98 (include)
    cmake_install.cmake:37 (include)
```


Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>