### PR TITLE
Fixing player.prefab by removing unnecessary dependency on the server

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.h
@@ -18,13 +18,7 @@ namespace MultiplayerSample
     public:
         AZ_MULTIPLAYER_COMPONENT(MultiplayerSample::WeaponEffectComponent, s_weaponEffectComponentConcreteUuid, MultiplayerSample::WeaponEffectComponentBase);
 
-        static void Reflect(AZ::ReflectContext* context);
-
-        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
-        {
-            WeaponEffectComponentBase::GetRequiredServices(required);
-            required.push_back(AZ_CRC("PopcornFXEmitterService"));
-        }
+        static void Reflect(AZ::ReflectContext* context);        
         
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;


### PR DESCRIPTION
Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>

PopcornFX isn't enabled by servers, so this leads to issues when instantiating the player prefab.