### PR TITLE
Fix soundeffect warning

### DIFF
--- a/Gem/Code/Include/GameplayEffectsNotificationBus.h
+++ b/Gem/Code/Include/GameplayEffectsNotificationBus.h
@@ -69,3 +69,8 @@ namespace MultiplayerSample
 
     using LocalOnlyGameplayEffectsNotificationBus = AZ::EBus<GameplayEffectsNotifications>;
 }
+
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(MultiplayerSample::SoundEffect, "{1A214937-62F2-4724-A66C-CC3E9D4F1F2F}");
+}


### PR DESCRIPTION
This fixes the warning that RPC_OnEffect has the wrong number of parameters. The warning boils down to the fact that AZ::Event<SoundEffect> had the same type ID as AZ::Event<> since the SoundEffect enum didn't have a specialized UUID.