### PR TITLE
Fix round timer by adding HUDComponent back in.

### DIFF
--- a/Levels/NewStarbase/NewStarbase.prefab
+++ b/Levels/NewStarbase/NewStarbase.prefab
@@ -7839,6 +7839,15 @@
                         "Entity_[330728780538767]"
                     ]
                 },
+                "Component_[8615741586168280576]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 8615741586168280576,
+                    "m_template": {
+                        "$type": "MultiplayerSample::HUDComponent",
+                        "RoundNumberId": 8,
+                        "RoundTimerId": 4
+                    }
+                },
                 "Component_[8823626037987064928]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8823626037987064928


### PR DESCRIPTION
The NewStarbase level was missing the HUDComponent, so nothing was causing the round timer and round counter to update. This PR adds it back in, so they function once more.

After the change:
![image](https://user-images.githubusercontent.com/82224783/215183793-ee50b7d5-ee35-4081-8e23-49bf086d02af.png)
