### PR TITLE
Add Client and Server Module declarations for MPS

### DIFF
--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -62,4 +62,8 @@ namespace MultiplayerSample
 // DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
 // The first parameter should be GemName_GemIdLower
 // The second should be the fully qualified name of the class above
+#if defined(AZ_MONOLITHIC_BUILD)
+AZ_DECLARE_MODULE_CLASS(Gem_MultiplayerSample_Client, MultiplayerSample::MultiplayerSampleModule);
+AZ_DECLARE_MODULE_CLASS(Gem_MultiplayerSample_Server, MultiplayerSample::MultiplayerSampleModule);
+#endif
 AZ_DECLARE_MODULE_CLASS(Gem_MultiplayerSample, MultiplayerSample::MultiplayerSampleModule)


### PR DESCRIPTION
Cherry picking a fix from development to GameJam_2022 07_branch.

The original fix is https://github.com/o3de/o3de-multiplayersample/commit/0750a65f30f882420c89d7a6353cf5a1a7a1b7fb

INSTALL target in release monolithic now succeeds.

Fixes https://github.com/o3de/o3de-multiplayersample/issues/216