### PR TITLE
Manually fixed actor patches

### DIFF
--- a/Levels/NewStarbase/NewStarbase.prefab
+++ b/Levels/NewStarbase/NewStarbase.prefab
@@ -18806,20 +18806,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.749918937683104
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -18845,20 +18831,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.749918937683104
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -18884,20 +18856,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.881239891052246
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -18923,20 +18881,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.749918937683104
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -18962,20 +18906,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.749918937683104
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19001,20 +18931,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 10.749918937683104
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19045,20 +18961,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -87.67607116699219
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19089,20 +18991,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -87.67607116699219
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19133,20 +19021,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -87.67607116699219
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19177,20 +19051,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -166.68724060058594
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19221,20 +19081,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -165.5677032470703
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -19265,20 +19111,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -165.5677032470703
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -25204,20 +25036,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Rotate/2",
                     "value": -166.68724060058594
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },
@@ -34611,20 +34429,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
                     "value": 1.6346101760864258
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/1",
-                    "value": {
-                        "AssetPath": ""
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[16129378600283]/Components/Component_[17838866209865688949]/MaterialPerLOD/2",
-                    "value": {
-                        "AssetPath": ""
-                    }
                 }
             ]
         },


### PR DESCRIPTION
Manually adjusted the json in the level file to remove the instance patches for the "MaterialPerLOD" field that no longer exists on the Actor component in the Player_spawner.prefab file.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>