### PR TITLE
Fix incorrect prefab casing and missing static rigid bodies.

### DIFF
--- a/Levels/Alpha/Alpha.prefab
+++ b/Levels/Alpha/Alpha.prefab
@@ -25480,7 +25480,7 @@
             ]
         },
         "Instance_[303496505956739]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgLG_D.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldglg_D.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -25530,7 +25530,7 @@
             ]
         },
         "Instance_[303543750596995]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgLG_D.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldglg_D.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26830,7 +26830,7 @@
             ]
         },
         "Instance_[43960222194051]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_A.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgmd_A.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26865,7 +26865,7 @@
             ]
         },
         "Instance_[43994581932419]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_A.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgmd_A.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26900,7 +26900,7 @@
             ]
         },
         "Instance_[44054711474563]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgLG_F.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldglg_F.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28825,7 +28825,7 @@
             ]
         },
         "Instance_[671094166886787]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgSM_M.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgsm_M.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28850,7 +28850,7 @@
             ]
         },
         "Instance_[671154296428931]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_G.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgmd_G.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28885,7 +28885,7 @@
             ]
         },
         "Instance_[671261670611331]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_E.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgmd_E.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -29075,7 +29075,7 @@
             ]
         },
         "Instance_[835166212561283]": {
-            "Source": "KB3D_HighTechStreets/Prefabs/HTS_BldgMD_J.prefab",
+            "Source": "KB3D_HighTechStreets/Prefabs/HTS_Bldgmd_J.prefab",
             "Patches": [
                 {
                     "op": "replace",

--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -7469,6 +7469,10 @@
             "Id": "Entity_[412839637138]",
             "Name": "Ground",
             "Components": {
+                "Component_[13978660823001526861]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13978660823001526861
+                },
                 "Component_[14576502551830180300]": {
                     "$type": "EditorColliderComponent",
                     "Id": 14576502551830180300,
@@ -7483,11 +7487,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -8203,6 +8202,10 @@
                 "Component_[314388126526494153]": {
                     "$type": "EditorLockComponent",
                     "Id": 314388126526494153
+                },
+                "Component_[3184154808274359768]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3184154808274359768
                 },
                 "Component_[4556394461817145286]": {
                     "$type": "EditorShapeColliderComponent",

--- a/Levels/NewStarbase/NewStarbase.prefab
+++ b/Levels/NewStarbase/NewStarbase.prefab
@@ -10649,6 +10649,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 1812876309289861994
                 },
+                "Component_[3812943563826593833]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3812943563826593833
+                },
                 "Component_[4733552064500071775]": {
                     "$type": "EditorLockComponent",
                     "Id": 4733552064500071775
@@ -10754,6 +10758,10 @@
                             19.907989501953125
                         ]
                     }
+                },
+                "Component_[9070683240441726139]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9070683240441726139
                 },
                 "Component_[947243610292482930]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -10873,6 +10881,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 1802261206987871613
                 },
+                "Component_[2400447888421128236]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2400447888421128236
+                },
                 "Component_[3222400375039180508]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 3222400375039180508
@@ -10957,6 +10969,10 @@
                 "Component_[7297306936785989589]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 7297306936785989589
+                },
+                "Component_[9441787202281326148]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9441787202281326148
                 }
             }
         },
@@ -11006,6 +11022,10 @@
                 "Component_[15374988758860579492]": {
                     "$type": "EditorLockComponent",
                     "Id": 15374988758860579492
+                },
+                "Component_[15739669499728732252]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15739669499728732252
                 },
                 "Component_[15743538600653137696]": {
                     "$type": "EditorVisibilityComponent",
@@ -11190,6 +11210,7 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 169555594784660831,
                     "Child Entity Order": [
+                        "Instance_[34369300484124]/ContainerEntity",
                         "Instance_[244590891542927]/ContainerEntity",
                         "Instance_[34318143886290]/ContainerEntity",
                         "Entity_[60257510040463]",
@@ -15154,6 +15175,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -15201,6 +15227,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -15254,6 +15285,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -15304,6 +15340,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -15320,7 +15361,7 @@
             ]
         },
         "Instance_[1005271236287602]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15355,7 +15396,7 @@
             ]
         },
         "Instance_[1005275531254898]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15390,7 +15431,7 @@
             ]
         },
         "Instance_[1005279826222194]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15425,7 +15466,7 @@
             ]
         },
         "Instance_[1005284121189490]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15460,7 +15501,7 @@
             ]
         },
         "Instance_[1005288416156786]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15495,7 +15536,7 @@
             ]
         },
         "Instance_[1005292711124082]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15530,7 +15571,7 @@
             ]
         },
         "Instance_[1005297006091378]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15565,7 +15606,7 @@
             ]
         },
         "Instance_[1005301301058674]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15600,7 +15641,7 @@
             ]
         },
         "Instance_[1005305596025970]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15670,7 +15711,7 @@
             ]
         },
         "Instance_[1005400085306482]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15790,7 +15831,7 @@
             ]
         },
         "Instance_[1005468804783218]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15825,7 +15866,7 @@
             ]
         },
         "Instance_[1005473099750514]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15860,7 +15901,7 @@
             ]
         },
         "Instance_[1005477394717810]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15895,7 +15936,7 @@
             ]
         },
         "Instance_[1005481689685106]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15930,7 +15971,7 @@
             ]
         },
         "Instance_[1005485984652402]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15965,7 +16006,7 @@
             ]
         },
         "Instance_[1005490279619698]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -16000,7 +16041,7 @@
             ]
         },
         "Instance_[1005494574586994]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -16035,7 +16076,7 @@
             ]
         },
         "Instance_[1005498869554290]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -16070,7 +16111,7 @@
             ]
         },
         "Instance_[1005503164521586]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -16309,6 +16350,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16356,6 +16402,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -16449,6 +16500,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16496,6 +16552,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -16549,6 +16610,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16596,6 +16662,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -16649,6 +16720,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16699,6 +16775,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16746,6 +16827,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -16869,6 +16955,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16929,6 +17020,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -16966,6 +17062,21 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2007546990608939644]/Transform Data/Translate/2",
                     "value": -16.630935668945313
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26440158776702]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26453043678590]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[52544970001790]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -17185,7 +17296,7 @@
             ]
         },
         "Instance_[1105352460827459]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -17316,6 +17427,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -17686,6 +17802,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -17716,6 +17837,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -17746,6 +17872,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -17806,6 +17937,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -18541,6 +18677,21 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2007546990608939644]/Transform Data/Translate/2",
                     "value": -16.744861602783203
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26440158776702]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26453043678590]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[52544970001790]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -18571,6 +18722,21 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2007546990608939644]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26440158776702]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26453043678590]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[52544970001790]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -18606,6 +18772,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -19146,6 +19317,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -19805,7 +19981,7 @@
             ]
         },
         "Instance_[24168316877277]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -19835,7 +20011,7 @@
             ]
         },
         "Instance_[24275691059677]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -19865,7 +20041,7 @@
             ]
         },
         "Instance_[24301460863453]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -24105,7 +24281,7 @@
             ]
         },
         "Instance_[2589848607934200]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26015,7 +26191,7 @@
             ]
         },
         "Instance_[26783951960541]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26280,7 +26456,7 @@
             ]
         },
         "Instance_[27200563788253]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26310,7 +26486,7 @@
             ]
         },
         "Instance_[27234923526621]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26340,7 +26516,7 @@
             ]
         },
         "Instance_[27247808428509]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26370,7 +26546,7 @@
             ]
         },
         "Instance_[27260693330397]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26400,7 +26576,7 @@
             ]
         },
         "Instance_[27273578232285]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -27914,8 +28090,18 @@
                 }
             ]
         },
+        "Instance_[34369300484124]": {
+            "Source": "Prefabs/GamePlay_Effects.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[13490474510842214515]/Parent Entity",
+                    "value": "../Entity_[767186398073361]"
+                }
+            ]
+        },
         "Instance_[35214746578625]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28145,7 +28331,7 @@
             ]
         },
         "Instance_[363335537380539]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28185,7 +28371,7 @@
             ]
         },
         "Instance_[363339832347835]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -28225,7 +28411,7 @@
             ]
         },
         "Instance_[363344127315131]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -29274,6 +29460,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29321,6 +29512,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29374,6 +29570,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29421,6 +29622,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29474,6 +29680,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29521,6 +29732,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29574,6 +29790,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29621,6 +29842,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29674,6 +29900,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29721,6 +29952,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29774,6 +30010,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29821,6 +30062,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -29874,6 +30120,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29924,6 +30175,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -29971,6 +30227,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -31523,7 +31784,7 @@
             ]
         },
         "Instance_[43699776244923]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -32042,6 +32303,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32089,6 +32355,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -32172,6 +32443,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32252,6 +32528,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32312,6 +32593,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32362,6 +32648,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32404,6 +32695,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -32457,6 +32753,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32507,6 +32808,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32549,6 +32855,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -32624,6 +32935,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -32717,6 +33033,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32767,6 +33088,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32809,6 +33135,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -32907,6 +33238,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -32954,6 +33290,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33067,6 +33408,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33114,6 +33460,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33232,6 +33583,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33304,6 +33660,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -33339,6 +33700,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33402,6 +33768,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33449,6 +33820,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33502,6 +33878,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33549,6 +33930,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33602,6 +33988,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33652,6 +34043,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33699,6 +34095,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33782,6 +34183,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33857,6 +34263,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -33904,6 +34315,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -33967,6 +34383,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34014,6 +34435,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34094,6 +34520,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34199,6 +34630,21 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2007546990608939644]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26440158776702]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[26453043678590]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Instances/Instance_[52544970001790]/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -34234,6 +34680,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34309,6 +34760,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34389,6 +34845,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34502,6 +34963,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34549,6 +35015,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34602,6 +35073,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34652,6 +35128,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34694,6 +35175,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34747,6 +35233,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34794,6 +35285,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34877,6 +35373,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -34924,6 +35425,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -34987,6 +35493,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35032,6 +35543,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35074,6 +35590,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35127,6 +35648,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35174,6 +35700,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35249,6 +35780,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35332,6 +35868,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35392,6 +35933,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35439,6 +35985,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35519,6 +36070,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35612,6 +36168,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35659,6 +36220,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35712,6 +36278,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35759,6 +36330,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -35837,6 +36413,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -35884,6 +36465,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36012,6 +36598,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36059,6 +36650,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36147,6 +36743,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36189,6 +36790,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36242,6 +36848,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36284,6 +36895,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36362,6 +36978,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36409,6 +37030,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36462,6 +37088,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36509,6 +37140,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36562,6 +37198,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36609,6 +37250,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36662,6 +37308,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36709,6 +37360,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36762,6 +37418,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36812,6 +37473,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -36859,6 +37525,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -36967,6 +37638,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37014,6 +37690,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -37097,6 +37778,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37144,6 +37830,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -37227,6 +37918,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37274,6 +37970,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -37337,6 +38038,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37397,6 +38103,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37444,6 +38155,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -37497,6 +38213,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37544,6 +38265,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -37597,6 +38323,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37647,6 +38378,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -37689,6 +38425,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38002,6 +38743,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -38049,6 +38795,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38102,6 +38853,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -38149,6 +38905,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38202,6 +38963,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -38249,6 +39015,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38302,6 +39073,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -38349,6 +39125,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38418,7 +39199,7 @@
             ]
         },
         "Instance_[576383730000783]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -38448,7 +39229,7 @@
             ]
         },
         "Instance_[576422384706447]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -38503,7 +39284,7 @@
             ]
         },
         "Instance_[576658607907727]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -38528,7 +39309,7 @@
             ]
         },
         "Instance_[576671492809615]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -38729,6 +39510,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -38759,6 +39545,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -38789,6 +39580,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -38819,6 +39615,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 }
             ]
         },
@@ -38854,6 +39655,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -38907,6 +39713,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -38954,6 +39765,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39007,6 +39823,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39054,6 +39875,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39107,6 +39933,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39154,6 +39985,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39207,6 +40043,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39254,6 +40095,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39307,6 +40153,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39354,6 +40205,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39407,6 +40263,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39454,6 +40315,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39507,6 +40373,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39554,6 +40425,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39607,6 +40483,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39654,6 +40535,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -39707,6 +40593,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39757,6 +40648,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -39804,6 +40700,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -40488,7 +41389,7 @@
             ]
         },
         "Instance_[577594910778255]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -40518,7 +41419,7 @@
             ]
         },
         "Instance_[577607795680143]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -40558,7 +41459,7 @@
             ]
         },
         "Instance_[577612090647439]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -42967,6 +43868,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43014,6 +43920,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43067,6 +43978,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43117,6 +44033,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43164,6 +44085,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43224,6 +44150,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43302,6 +44233,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43349,6 +44285,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43402,6 +44343,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43449,6 +44395,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43502,6 +44453,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43549,6 +44505,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43602,6 +44563,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43649,6 +44615,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43702,6 +44673,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43749,6 +44725,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43802,6 +44783,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43849,6 +44835,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -43902,6 +44893,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -43949,6 +44945,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -44002,6 +45003,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -44049,6 +45055,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -44102,6 +45113,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -44149,6 +45165,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -44202,6 +45223,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -44249,6 +45275,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -44302,6 +45333,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -44349,6 +45385,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -45657,6 +46698,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -45704,6 +46750,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -45757,6 +46808,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -45804,6 +46860,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -45857,6 +46918,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -45904,6 +46970,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -45957,6 +47028,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -46004,6 +47080,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -46057,6 +47138,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -46104,6 +47190,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -46157,6 +47248,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -46204,6 +47300,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -46257,6 +47358,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -46307,6 +47413,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -46354,6 +47465,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -47522,6 +48638,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -47582,6 +48703,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -47629,6 +48755,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -47682,6 +48813,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -47732,6 +48868,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -47779,6 +48920,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -47854,6 +49000,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -50517,6 +51668,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -50559,6 +51715,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -50607,6 +51768,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -50649,6 +51815,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -53297,6 +54468,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -53339,6 +54515,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -53387,6 +54568,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -53429,6 +54615,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -53528,7 +54719,7 @@
             ]
         },
         "Instance_[841559305823119]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53563,7 +54754,7 @@
             ]
         },
         "Instance_[841563600790415]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53633,7 +54824,7 @@
             ]
         },
         "Instance_[841597960528783]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53673,7 +54864,7 @@
             ]
         },
         "Instance_[841602255496079]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53713,7 +54904,7 @@
             ]
         },
         "Instance_[841606550463375]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53753,7 +54944,7 @@
             ]
         },
         "Instance_[841636615234447]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53793,7 +54984,7 @@
             ]
         },
         "Instance_[841640910201743]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53833,7 +55024,7 @@
             ]
         },
         "Instance_[841645205169039]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53873,7 +55064,7 @@
             ]
         },
         "Instance_[841675269940111]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53913,7 +55104,7 @@
             ]
         },
         "Instance_[841679564907407]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53953,7 +55144,7 @@
             ]
         },
         "Instance_[841701039743887]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -53993,7 +55184,7 @@
             ]
         },
         "Instance_[841705334711183]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -54033,7 +55224,7 @@
             ]
         },
         "Instance_[841726809547663]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -54073,7 +55264,7 @@
             ]
         },
         "Instance_[841731104514959]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -54247,6 +55438,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -54289,6 +55485,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -54342,6 +55543,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -54389,6 +55595,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -54442,6 +55653,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -54489,6 +55705,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -54542,6 +55763,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -54592,6 +55818,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -54639,6 +55870,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -54832,6 +56068,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55002,6 +56243,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55049,6 +56295,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -55102,6 +56353,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55149,6 +56405,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -55202,6 +56463,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55218,7 +56484,7 @@
             ]
         },
         "Instance_[87613573773789]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55287,6 +56553,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55303,7 +56574,7 @@
             ]
         },
         "Instance_[87643638544861]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55338,7 +56609,7 @@
             ]
         },
         "Instance_[87656523446749]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55407,6 +56678,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55423,7 +56699,7 @@
             ]
         },
         "Instance_[87669408348637]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55458,7 +56734,7 @@
             ]
         },
         "Instance_[87682293250525]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55493,7 +56769,7 @@
             ]
         },
         "Instance_[87695178152413]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55528,7 +56804,7 @@
             ]
         },
         "Instance_[87708063054301]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55597,6 +56873,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55613,7 +56894,7 @@
             ]
         },
         "Instance_[87720947956189]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55648,7 +56929,7 @@
             ]
         },
         "Instance_[87733832858077]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55683,7 +56964,7 @@
             ]
         },
         "Instance_[87746717759965]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55752,6 +57033,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -55768,7 +57054,7 @@
             ]
         },
         "Instance_[87759602661853]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55803,7 +57089,7 @@
             ]
         },
         "Instance_[87772487563741]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55838,7 +57124,7 @@
             ]
         },
         "Instance_[87785372465629]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55908,7 +57194,7 @@
             ]
         },
         "Instance_[87836912073181]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55948,7 +57234,7 @@
             ]
         },
         "Instance_[87849796975069]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -55988,7 +57274,7 @@
             ]
         },
         "Instance_[87862681876957]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -56028,7 +57314,7 @@
             ]
         },
         "Instance_[87875566778845]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -56068,7 +57354,7 @@
             ]
         },
         "Instance_[87888451680733]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -56108,7 +57394,7 @@
             ]
         },
         "Instance_[87901336582621]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -56392,6 +57678,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56442,6 +57733,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56489,6 +57785,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -56562,6 +57863,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56604,6 +57910,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -56652,6 +57963,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56694,6 +58010,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -56742,6 +58063,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56784,6 +58110,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -56832,6 +58163,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56874,6 +58210,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -56922,6 +58263,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -56967,6 +58313,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57009,6 +58360,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57062,6 +58418,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57109,6 +58470,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57162,6 +58528,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57212,6 +58583,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57259,6 +58635,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57382,6 +58763,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57429,6 +58815,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57482,6 +58873,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57529,6 +58925,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57582,6 +58983,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57629,6 +59035,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57682,6 +59093,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57729,6 +59145,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57782,6 +59203,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57829,6 +59255,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57882,6 +59313,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -57929,6 +59365,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -57982,6 +59423,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58029,6 +59475,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58082,6 +59533,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58129,6 +59585,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58182,6 +59643,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58229,6 +59695,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58282,6 +59753,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58329,6 +59805,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58437,6 +59918,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58484,6 +59970,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58537,6 +60028,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58584,6 +60080,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58637,6 +60138,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58684,6 +60190,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58737,6 +60248,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58784,6 +60300,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58837,6 +60358,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58884,6 +60410,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",
@@ -58937,6 +60468,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -58987,6 +60523,11 @@
                 },
                 {
                     "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
+                },
+                {
+                    "op": "replace",
                     "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ShapeConfiguration/PhysicsAsset/Configuration/Scale/0",
                     "value": 0.7151455283164978
                 },
@@ -59034,6 +60575,11 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/UniformScale",
                     "value": 0.7151455283164978
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[9765677058485]/Components/Component_[13953719371560068493]/ColliderConfiguration/MaterialSlots/Slots/0/Name",
+                    "value": "KB3D_HTS_MetalGrey"
                 },
                 {
                     "op": "replace",

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -1027,11 +1027,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -1124,6 +1119,10 @@
                 "Component_[3412423409421084023]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 3412423409421084023
+                },
+                "Component_[6375999153465371421]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6375999153465371421
                 }
             }
         },
@@ -1195,6 +1194,10 @@
                 "Component_[13545070526863732984]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13545070526863732984
+                },
+                "Component_[14642535321177819542]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14642535321177819542
                 },
                 "Component_[2917092960552172245]": {
                     "$type": "EditorVisibilityComponent",

--- a/Levels/SpawningPerfTest/SpawningPerfTest.prefab
+++ b/Levels/SpawningPerfTest/SpawningPerfTest.prefab
@@ -308,11 +308,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -330,6 +325,10 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 380249072065273654,
                     "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[6965166023288118996]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6965166023288118996
                 },
                 "Component_[7476660583684339787]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Prefabs/Ground_Teleport_Volume.prefab
+++ b/Prefabs/Ground_Teleport_Volume.prefab
@@ -148,6 +148,10 @@
                         ]
                     }
                 },
+                "Component_[5965617868763001731]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5965617868763001731
+                },
                 "Component_[6232834962003349701]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 6232834962003349701

--- a/Prefabs/Horizontal_Teleporter_01.prefab
+++ b/Prefabs/Horizontal_Teleporter_01.prefab
@@ -156,6 +156,10 @@
             "Id": "Entity_[576499694117775]",
             "Name": "Horizontal_Teleporter_01_Enter",
             "Components": {
+                "Component_[12337560235052437266]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12337560235052437266
+                },
                 "Component_[15887976581344016802]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15887976581344016802

--- a/Prefabs/Levels/Starbase/StarbaseWIP.prefab
+++ b/Prefabs/Levels/Starbase/StarbaseWIP.prefab
@@ -156,6 +156,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 16919232076966545697
                 },
+                "Component_[4204041649505339034]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4204041649505339034
+                },
                 "Component_[5182430712893438093]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 5182430712893438093
@@ -2955,6 +2959,10 @@
                         }
                     }
                 },
+                "Component_[13936198506082349075]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13936198506082349075
+                },
                 "Component_[15288026845790047287]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15288026845790047287
@@ -3076,6 +3084,10 @@
                 "Component_[6041309827385475293]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 6041309827385475293
+                },
+                "Component_[7686517751395889447]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7686517751395889447
                 }
             }
         },
@@ -3086,6 +3098,10 @@
                 "Component_[10868691291115504704]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 10868691291115504704
+                },
+                "Component_[11814613422869863014]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11814613422869863014
                 },
                 "Component_[13693925478346833413]": {
                     "$type": "EditorLockComponent",
@@ -3198,6 +3214,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1515434422137485373
                 },
+                "Component_[17483821605816287986]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17483821605816287986
+                },
                 "Component_[17767567529755615033]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17767567529755615033,
@@ -3294,6 +3314,10 @@
                 "Component_[6457083610128280813]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 6457083610128280813
+                },
+                "Component_[7015486230014584449]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7015486230014584449
                 },
                 "Component_[7297306936785989589]": {
                     "$type": "EditorPendingCompositionComponent",
@@ -10095,7 +10119,7 @@
                     "Id": 1338531389170705021,
                     "Child Entity Order": [
                         "Instance_[40338284743604]/ContainerEntity",
-                        "Instance_[94235658361970]/ContainerEntity",
+                        "",
                         "Instance_[390764495445106]/ContainerEntity",
                         "Instance_[390820330019954]/ContainerEntity",
                         "Instance_[390863279692914]/ContainerEntity",
@@ -10201,7 +10225,7 @@
                         "Instance_[44000423955643]/ContainerEntity",
                         "Instance_[43747020885179]/ContainerEntity",
                         "Entity_[363331242413243]",
-                        "Instance_[363374192086203]/ContainerEntity",
+                        "",
                         "Instance_[363550285745339]/ContainerEntity",
                         "Entity_[363661954895035]",
                         "Instance_[363679134764219]/ContainerEntity",
@@ -12662,6 +12686,10 @@
                     "Id": 7090012899106946164,
                     "Locked": true
                 },
+                "Component_[9409035750888866460]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9409035750888866460
+                },
                 "Component_[9410832619875640998]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 9410832619875640998
@@ -12921,7 +12949,7 @@
             ]
         },
         "Instance_[1005271236287602]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -12956,7 +12984,7 @@
             ]
         },
         "Instance_[1005275531254898]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -12991,7 +13019,7 @@
             ]
         },
         "Instance_[1005279826222194]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13026,7 +13054,7 @@
             ]
         },
         "Instance_[1005284121189490]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13061,7 +13089,7 @@
             ]
         },
         "Instance_[1005288416156786]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13096,7 +13124,7 @@
             ]
         },
         "Instance_[1005292711124082]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13131,7 +13159,7 @@
             ]
         },
         "Instance_[1005297006091378]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13166,7 +13194,7 @@
             ]
         },
         "Instance_[1005301301058674]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13201,7 +13229,7 @@
             ]
         },
         "Instance_[1005305596025970]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13271,7 +13299,7 @@
             ]
         },
         "Instance_[1005400085306482]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13391,7 +13419,7 @@
             ]
         },
         "Instance_[1005468804783218]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13426,7 +13454,7 @@
             ]
         },
         "Instance_[1005473099750514]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13461,7 +13489,7 @@
             ]
         },
         "Instance_[1005477394717810]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13496,7 +13524,7 @@
             ]
         },
         "Instance_[1005481689685106]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13531,7 +13559,7 @@
             ]
         },
         "Instance_[1005485984652402]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13566,7 +13594,7 @@
             ]
         },
         "Instance_[1005490279619698]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13601,7 +13629,7 @@
             ]
         },
         "Instance_[1005494574586994]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13636,7 +13664,7 @@
             ]
         },
         "Instance_[1005498869554290]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13671,7 +13699,7 @@
             ]
         },
         "Instance_[1005503164521586]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15065,12 +15093,12 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[12135421661699558710]/Transform Data/Translate/1",
-                    "value": -12.561079025268555
+                    "value": -12.561079025268556
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[12135421661699558710]/Transform Data/Translate/2",
-                    "value": 19.925935745239258
+                    "value": 19.925935745239254
                 },
                 {
                     "op": "replace",
@@ -15092,7 +15120,7 @@
             "Source": "E_Barricade/E_barricade.prefab"
         },
         "Instance_[1105352460827459]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15102,7 +15130,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Translate/0",
-                    "value": 96.86895751953125
+                    "value": 96.86895751953124
                 },
                 {
                     "op": "replace",
@@ -15117,17 +15145,17 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/0",
-                    "value": -0.24052225053310394
+                    "value": -0.24052225053310392
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": -1.6912403106689453
+                    "value": -1.691240310668945
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/2",
-                    "value": -98.10778045654297
+                    "value": -98.10778045654295
                 }
             ]
         },
@@ -15187,7 +15215,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[6156020711088215144]/Transform Data/Translate/2",
-                    "value": 26.055461883544922
+                    "value": 26.05546188354492
                 },
                 {
                     "op": "replace",
@@ -15217,7 +15245,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/2",
-                    "value": 14.981470108032227
+                    "value": 14.981470108032228
                 },
                 {
                     "op": "replace",
@@ -15457,12 +15485,12 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13229839974588332606]/Transform Data/Translate/2",
-                    "value": 15.344029426574707
+                    "value": 15.344029426574709
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13229839974588332606]/Transform Data/Rotate/2",
-                    "value": -113.11299133300781
+                    "value": -113.1129913330078
                 }
             ]
         },
@@ -15492,7 +15520,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13229839974588332606]/Transform Data/Rotate/2",
-                    "value": -113.11299133300781
+                    "value": -113.1129913330078
                 }
             ]
         },
@@ -15522,7 +15550,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13229839974588332606]/Transform Data/Rotate/2",
-                    "value": -113.11299133300781
+                    "value": -113.1129913330078
                 }
             ]
         },
@@ -15637,7 +15665,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/2",
-                    "value": 18.468708038330078
+                    "value": 18.46870803833008
                 },
                 {
                     "op": "replace",
@@ -15667,7 +15695,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/2",
-                    "value": 14.981470108032227
+                    "value": 14.981470108032228
                 },
                 {
                     "op": "replace",
@@ -15727,7 +15755,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/2",
-                    "value": 18.468708038330078
+                    "value": 18.46870803833008
                 },
                 {
                     "op": "replace",
@@ -16121,7 +16149,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 11.680360794067383
+                    "value": 11.680360794067385
                 }
             ]
         },
@@ -16146,7 +16174,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 11.680360794067383
+                    "value": 11.680360794067385
                 }
             ]
         },
@@ -16171,7 +16199,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 11.680360794067383
+                    "value": 11.680360794067385
                 }
             ]
         },
@@ -16196,7 +16224,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 11.680360794067383
+                    "value": 11.680360794067385
                 }
             ]
         },
@@ -16226,7 +16254,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Rotate/0",
-                    "value": 90.34956359863281
+                    "value": 90.3495635986328
                 },
                 {
                     "op": "replace",
@@ -16321,7 +16349,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 11.680360794067383
+                    "value": 11.680360794067385
                 }
             ]
         },
@@ -16481,7 +16509,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 63.420082092285156
+                    "value": 63.42008209228515
                 },
                 {
                     "op": "replace",
@@ -18408,7 +18436,7 @@
             ]
         },
         "Instance_[24168316877277]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -18438,7 +18466,7 @@
             ]
         },
         "Instance_[24275691059677]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -18468,7 +18496,7 @@
             ]
         },
         "Instance_[24301460863453]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -22738,7 +22766,7 @@
             ]
         },
         "Instance_[2589848607934200]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -23427,7 +23455,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/2",
-                    "value": 22.861858367919922
+                    "value": 22.86185836791992
                 }
             ]
         },
@@ -23452,7 +23480,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/2",
-                    "value": 22.861858367919922
+                    "value": 22.86185836791992
                 }
             ]
         },
@@ -24004,7 +24032,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11106670523878836401]/Transform Data/Translate/0",
-                    "value": 56.837486267089844
+                    "value": 56.83748626708984
                 },
                 {
                     "op": "replace",
@@ -24079,7 +24107,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11106670523878836401]/Transform Data/Translate/1",
-                    "value": 12.122123718261719
+                    "value": 12.12212371826172
                 },
                 {
                     "op": "replace",
@@ -24144,7 +24172,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11106670523878836401]/Transform Data/Translate/0",
-                    "value": 56.837486267089844
+                    "value": 56.83748626708984
                 },
                 {
                     "op": "replace",
@@ -24184,7 +24212,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11106670523878836401]/Transform Data/Translate/1",
-                    "value": 14.258513450622559
+                    "value": 14.25851345062256
                 },
                 {
                     "op": "replace",
@@ -24689,7 +24717,7 @@
             ]
         },
         "Instance_[26783951960541]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -24919,7 +24947,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9258688643060159915]/Transform Data/Rotate/1",
-                    "value": -1.7202723026275635
+                    "value": -1.7202723026275637
                 },
                 {
                     "op": "replace",
@@ -24964,7 +24992,7 @@
             ]
         },
         "Instance_[27200563788253]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -24974,7 +25002,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8292154386652853697]/Transform Data/Translate/0",
-                    "value": 103.22427368164063
+                    "value": 103.22427368164064
                 },
                 {
                     "op": "replace",
@@ -24994,7 +25022,7 @@
             ]
         },
         "Instance_[27234923526621]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -25004,7 +25032,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8292154386652853697]/Transform Data/Translate/0",
-                    "value": 97.34194946289063
+                    "value": 97.34194946289064
                 },
                 {
                     "op": "replace",
@@ -25024,7 +25052,7 @@
             ]
         },
         "Instance_[27247808428509]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -25054,7 +25082,7 @@
             ]
         },
         "Instance_[27260693330397]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -25084,7 +25112,7 @@
             ]
         },
         "Instance_[27273578232285]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26474,7 +26502,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9966736445084823710]/Transform Data/Translate/2",
-                    "value": 11.675999641418457
+                    "value": 11.675999641418455
                 }
             ]
         },
@@ -26663,7 +26691,7 @@
             "Source": "E_Barricade/E_barricade.prefab"
         },
         "Instance_[35214746578625]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26768,7 +26796,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9258688643060159915]/Transform Data/Translate/1",
-                    "value": -10.006062507629395
+                    "value": -10.006062507629396
                 },
                 {
                     "op": "replace",
@@ -26893,7 +26921,7 @@
             ]
         },
         "Instance_[363335537380539]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26913,7 +26941,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Translate/2",
-                    "value": 19.281404495239258
+                    "value": 19.281404495239254
                 },
                 {
                     "op": "replace",
@@ -26933,7 +26961,7 @@
             ]
         },
         "Instance_[363339832347835]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26973,7 +27001,7 @@
             ]
         },
         "Instance_[363344127315131]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -26993,7 +27021,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Translate/2",
-                    "value": 15.367707252502441
+                    "value": 15.36770725250244
                 },
                 {
                     "op": "replace",
@@ -27013,29 +27041,7 @@
             ]
         },
         "Instance_[363374192086203]": {
-            "Source": "Teleporter_Platform/TeleporterGround02.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[4789123684229387608]/Parent Entity",
-                    "value": "../Entity_[69306349366933]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[4789123684229387608]/Transform Data/Translate/0",
-                    "value": 119.82259368896484
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[4789123684229387608]/Transform Data/Translate/1",
-                    "value": -27.74736785888672
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[4789123684229387608]/Transform Data/Translate/2",
-                    "value": 4.76837158203125e-7
-                }
-            ]
+            "Source": "Teleporter_Platform/TeleporterGround02.prefab"
         },
         "Instance_[363550285745339]": {
             "Source": "EBarricade/EBarricade_Small.prefab",
@@ -27188,7 +27194,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 9.762758255004883
+                    "value": 9.762758255004885
                 },
                 {
                     "op": "replace",
@@ -27328,7 +27334,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[10406703446304744333]/Transform Data/Translate/2",
-                    "value": 11.404393196105957
+                    "value": 11.404393196105955
                 }
             ]
         },
@@ -27353,7 +27359,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[10406703446304744333]/Transform Data/Translate/2",
-                    "value": 11.652726173400879
+                    "value": 11.65272617340088
                 },
                 {
                     "op": "replace",
@@ -27713,7 +27719,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 91.78814697265625
+                    "value": 91.78814697265624
                 },
                 {
                     "op": "replace",
@@ -27908,7 +27914,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11643599802128616532]/Transform Data/Translate/0",
-                    "value": 107.39265441894531
+                    "value": 107.39265441894533
                 },
                 {
                     "op": "replace",
@@ -27943,7 +27949,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[10046873803164473926]/Transform Data/Translate/2",
-                    "value": 18.999300003051758
+                    "value": 18.99930000305176
                 }
             ]
         },
@@ -28098,7 +28104,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13229839974588332606]/Transform Data/Translate/1",
-                    "value": 9.430891990661621
+                    "value": 9.43089199066162
                 },
                 {
                     "op": "replace",
@@ -28128,7 +28134,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9966736445084823710]/Transform Data/Translate/1",
-                    "value": 10.539177894592285
+                    "value": 10.539177894592283
                 },
                 {
                     "op": "replace",
@@ -28148,7 +28154,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15123881204268808031]/Transform Data/Translate/0",
-                    "value": 92.11723327636719
+                    "value": 92.1172332763672
                 },
                 {
                     "op": "replace",
@@ -28173,7 +28179,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15123881204268808031]/Transform Data/Translate/0",
-                    "value": 92.11723327636719
+                    "value": 92.1172332763672
                 },
                 {
                     "op": "replace",
@@ -28198,7 +28204,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15123881204268808031]/Transform Data/Translate/0",
-                    "value": 92.11723327636719
+                    "value": 92.1172332763672
                 },
                 {
                     "op": "replace",
@@ -28223,7 +28229,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[11643599802128616532]/Transform Data/Translate/0",
-                    "value": 108.19033813476563
+                    "value": 108.19033813476564
                 },
                 {
                     "op": "replace",
@@ -28248,7 +28254,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2815070735218165771]/Transform Data/Translate/0",
-                    "value": 106.07485961914063
+                    "value": 106.07485961914064
                 },
                 {
                     "op": "replace",
@@ -29098,7 +29104,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 117.50434875488281
+                    "value": 117.5043487548828
                 },
                 {
                     "op": "replace",
@@ -29123,7 +29129,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 112.29102325439453
+                    "value": 112.29102325439452
                 },
                 {
                     "op": "replace",
@@ -29148,7 +29154,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 120.09721374511719
+                    "value": 120.0972137451172
                 },
                 {
                     "op": "replace",
@@ -29173,7 +29179,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 112.29102325439453
+                    "value": 112.29102325439452
                 },
                 {
                     "op": "replace",
@@ -29198,7 +29204,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 117.50434875488281
+                    "value": 117.5043487548828
                 },
                 {
                     "op": "replace",
@@ -29223,7 +29229,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 120.09721374511719
+                    "value": 120.0972137451172
                 },
                 {
                     "op": "replace",
@@ -29248,7 +29254,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 112.29102325439453
+                    "value": 112.29102325439452
                 },
                 {
                     "op": "replace",
@@ -29273,7 +29279,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 117.50434875488281
+                    "value": 117.5043487548828
                 },
                 {
                     "op": "replace",
@@ -29298,7 +29304,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 120.09721374511719
+                    "value": 120.0972137451172
                 },
                 {
                     "op": "replace",
@@ -30686,7 +30692,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/2",
-                    "value": 11.697287559509277
+                    "value": 11.697287559509276
                 },
                 {
                     "op": "replace",
@@ -30916,7 +30922,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": -1.4414408206939697
+                    "value": -1.4414408206939695
                 },
                 {
                     "op": "replace",
@@ -31006,7 +31012,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 3.7556378841400146
+                    "value": 3.755637884140014
                 },
                 {
                     "op": "replace",
@@ -31216,7 +31222,7 @@
             ]
         },
         "Instance_[43699776244923]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -31291,7 +31297,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15151136896214454413]/Transform Data/Translate/2",
-                    "value": 14.259716033935547
+                    "value": 14.259716033935549
                 },
                 {
                     "op": "replace",
@@ -31316,7 +31322,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15151136896214454413]/Transform Data/Translate/1",
-                    "value": 21.735994338989258
+                    "value": 21.735994338989254
                 },
                 {
                     "op": "replace",
@@ -31381,7 +31387,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15151136896214454413]/Transform Data/Translate/2",
-                    "value": 14.889951705932617
+                    "value": 14.889951705932615
                 },
                 {
                     "op": "replace",
@@ -31441,7 +31447,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8879157216575694980]/Transform Data/Translate/2",
-                    "value": 15.562347412109375
+                    "value": 15.562347412109377
                 },
                 {
                     "op": "replace",
@@ -31461,7 +31467,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9966736445084823710]/Transform Data/Translate/0",
-                    "value": 105.59630584716797
+                    "value": 105.59630584716795
                 },
                 {
                     "op": "replace",
@@ -31596,7 +31602,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2000417864965542772]/Transform Data/Rotate/2",
-                    "value": -116.43909454345703
+                    "value": -116.43909454345705
                 },
                 {
                     "op": "replace",
@@ -31691,7 +31697,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9966736445084823710]/Transform Data/Translate/2",
-                    "value": 15.315934181213379
+                    "value": 15.31593418121338
                 }
             ]
         },
@@ -33026,7 +33032,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16237068544565649519]/Transform Data/Translate/1",
-                    "value": 28.015695571899414
+                    "value": 28.015695571899418
                 },
                 {
                     "op": "replace",
@@ -36422,12 +36428,12 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/1",
-                    "value": -1.6451916694641113
+                    "value": -1.645191669464111
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[15806820478732200410]/Transform Data/Translate/2",
-                    "value": 15.449483871459961
+                    "value": 15.44948387145996
                 },
                 {
                     "op": "add",
@@ -37380,7 +37386,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/0",
-                    "value": 103.07182312011719
+                    "value": 103.0718231201172
                 },
                 {
                     "op": "replace",
@@ -48650,7 +48656,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 126.25968933105469
+                    "value": 126.25968933105467
                 },
                 {
                     "op": "replace",
@@ -48880,7 +48886,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": -9.921746253967285
+                    "value": -9.921746253967283
                 },
                 {
                     "op": "replace",
@@ -49350,7 +49356,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 112.29102325439453
+                    "value": 112.29102325439452
                 },
                 {
                     "op": "replace",
@@ -49375,7 +49381,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[9803039979756737014]/Transform Data/Translate/0",
-                    "value": 120.09638977050781
+                    "value": 120.0963897705078
                 },
                 {
                     "op": "replace",
@@ -49765,12 +49771,12 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1443348170064532185]/Transform Data/Translate/0",
-                    "value": 114.96049499511719
+                    "value": 114.9604949951172
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1443348170064532185]/Transform Data/Translate/1",
-                    "value": 0.9528205394744873
+                    "value": 0.9528205394744872
                 },
                 {
                     "op": "replace",
@@ -49855,7 +49861,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1443348170064532185]/Transform Data/Translate/0",
-                    "value": 119.74307250976563
+                    "value": 119.74307250976564
                 },
                 {
                     "op": "replace",
@@ -50780,7 +50786,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -50820,7 +50826,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -50860,7 +50866,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -50900,7 +50906,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -50940,7 +50946,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -50980,7 +50986,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -51020,7 +51026,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -51060,7 +51066,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -51095,7 +51101,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 111.68560791015625
+                    "value": 111.68560791015624
                 },
                 {
                     "op": "replace",
@@ -51305,7 +51311,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 113.16638946533203
+                    "value": 113.16638946533205
                 },
                 {
                     "op": "replace",
@@ -51485,7 +51491,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 115.77236938476563
+                    "value": 115.77236938476564
                 },
                 {
                     "op": "replace",
@@ -51530,7 +51536,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 106.12873840332031
+                    "value": 106.12873840332033
                 },
                 {
                     "op": "replace",
@@ -51695,7 +51701,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 106.48184204101563
+                    "value": 106.48184204101564
                 },
                 {
                     "op": "replace",
@@ -51925,7 +51931,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 95.73406982421875
+                    "value": 95.73406982421876
                 },
                 {
                     "op": "replace",
@@ -51970,7 +51976,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 93.13604736328125
+                    "value": 93.13604736328124
                 },
                 {
                     "op": "replace",
@@ -52065,7 +52071,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -52100,12 +52106,12 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/0",
-                    "value": 91.46855163574219
+                    "value": 91.4685516357422
                 },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8538222073100498275]/Transform Data/Translate/1",
-                    "value": 15.533773422241211
+                    "value": 15.533773422241213
                 },
                 {
                     "op": "replace",
@@ -52258,7 +52264,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/0",
-                    "value": 103.46703338623047
+                    "value": 103.46703338623048
                 },
                 {
                     "op": "replace",
@@ -52328,7 +52334,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[18056289439526005371]/Transform Data/Translate/2",
-                    "value": 10.754373550415039
+                    "value": 10.75437355041504
                 },
                 {
                     "op": "replace",
@@ -53967,7 +53973,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[14813183333063698436]/Transform Data/Translate/1",
-                    "value": 13.283599853515625
+                    "value": 13.283599853515623
                 },
                 {
                     "op": "replace",
@@ -53997,7 +54003,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[14813183333063698436]/Transform Data/Translate/1",
-                    "value": 10.308158874511719
+                    "value": 10.30815887451172
                 },
                 {
                     "op": "replace",
@@ -54087,7 +54093,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[14813183333063698436]/Transform Data/Translate/1",
-                    "value": 11.797065734863281
+                    "value": 11.79706573486328
                 },
                 {
                     "op": "replace",
@@ -60400,7 +60406,7 @@
             ]
         },
         "Instance_[87613573773789]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60485,7 +60491,7 @@
             ]
         },
         "Instance_[87643638544861]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60520,7 +60526,7 @@
             ]
         },
         "Instance_[87656523446749]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60605,7 +60611,7 @@
             ]
         },
         "Instance_[87669408348637]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60640,7 +60646,7 @@
             ]
         },
         "Instance_[87682293250525]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60675,7 +60681,7 @@
             ]
         },
         "Instance_[87695178152413]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60710,7 +60716,7 @@
             ]
         },
         "Instance_[87708063054301]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60795,7 +60801,7 @@
             ]
         },
         "Instance_[87720947956189]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60830,7 +60836,7 @@
             ]
         },
         "Instance_[87733832858077]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60865,7 +60871,7 @@
             ]
         },
         "Instance_[87746717759965]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60950,7 +60956,7 @@
             ]
         },
         "Instance_[87759602661853]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -60985,7 +60991,7 @@
             ]
         },
         "Instance_[87772487563741]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61020,7 +61026,7 @@
             ]
         },
         "Instance_[87785372465629]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61090,7 +61096,7 @@
             ]
         },
         "Instance_[87836912073181]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61130,7 +61136,7 @@
             ]
         },
         "Instance_[87849796975069]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61170,7 +61176,7 @@
             ]
         },
         "Instance_[87862681876957]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61210,7 +61216,7 @@
             ]
         },
         "Instance_[87875566778845]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61250,7 +61256,7 @@
             ]
         },
         "Instance_[87888451680733]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -61290,7 +61296,7 @@
             ]
         },
         "Instance_[87901336582621]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -63828,29 +63834,7 @@
             ]
         },
         "Instance_[94235658361970]": {
-            "Source": "Teleporter_Platform/TeleporterGround01.prefab",
-            "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[9240736716032173341]/Parent Entity",
-                    "value": "../Entity_[69306349366933]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[9240736716032173341]/Transform Data/Translate/0",
-                    "value": 102.2625961303711
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[9240736716032173341]/Transform Data/Translate/1",
-                    "value": 34.815696716308594
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[9240736716032173341]/Transform Data/Translate/2",
-                    "value": 9.5367431640625e-7
-                }
-            ]
+            "Source": "Teleporter_Platform/TeleporterGround01.prefab"
         },
         "Instance_[9458153301158]": {
             "Source": "KB3D_HighTechStreets/Prefabs/HTS_Lift_A.prefab",

--- a/Prefabs/Levels/Starbase/Starbase_Level.prefab
+++ b/Prefabs/Levels/Starbase/Starbase_Level.prefab
@@ -232,6 +232,10 @@
                         ]
                     }
                 },
+                "Component_[15838596398635778551]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15838596398635778551
+                },
                 "Component_[15914408400572119926]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 15914408400572119926
@@ -485,6 +489,10 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 4788304045298460287
                 },
+                "Component_[5816494592438252238]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5816494592438252238
+                },
                 "Component_[6041309827385475293]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 6041309827385475293
@@ -604,6 +612,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5519823211633376101
                 },
+                "Component_[6071515701014068673]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6071515701014068673
+                },
                 "Component_[7590376288882843620]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7590376288882843620,
@@ -685,6 +697,10 @@
                 "Component_[6646255479239831073]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6646255479239831073
+                },
+                "Component_[6869863075919165803]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6869863075919165803
                 },
                 "Component_[7332331237880215974]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2146,6 +2162,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 1515434422137485373
                 },
+                "Component_[1732441199528601811]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1732441199528601811
+                },
                 "Component_[17767567529755615033]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 17767567529755615033,
@@ -2494,7 +2514,7 @@
             ]
         },
         "Instance_[1005271236287602]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2529,7 +2549,7 @@
             ]
         },
         "Instance_[1005275531254898]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2564,7 +2584,7 @@
             ]
         },
         "Instance_[1005279826222194]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2599,7 +2619,7 @@
             ]
         },
         "Instance_[1005284121189490]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2634,7 +2654,7 @@
             ]
         },
         "Instance_[1005288416156786]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2669,7 +2689,7 @@
             ]
         },
         "Instance_[1005292711124082]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2704,7 +2724,7 @@
             ]
         },
         "Instance_[1005297006091378]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2739,7 +2759,7 @@
             ]
         },
         "Instance_[1005301301058674]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2774,7 +2794,7 @@
             ]
         },
         "Instance_[1005305596025970]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2844,7 +2864,7 @@
             ]
         },
         "Instance_[1005400085306482]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2964,7 +2984,7 @@
             ]
         },
         "Instance_[1005468804783218]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -2999,7 +3019,7 @@
             ]
         },
         "Instance_[1005473099750514]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3034,7 +3054,7 @@
             ]
         },
         "Instance_[1005477394717810]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3069,7 +3089,7 @@
             ]
         },
         "Instance_[1005481689685106]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3104,7 +3124,7 @@
             ]
         },
         "Instance_[1005485984652402]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3139,7 +3159,7 @@
             ]
         },
         "Instance_[1005490279619698]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3174,7 +3194,7 @@
             ]
         },
         "Instance_[1005494574586994]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3209,7 +3229,7 @@
             ]
         },
         "Instance_[1005498869554290]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -3244,7 +3264,7 @@
             ]
         },
         "Instance_[1005503164521586]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -4614,7 +4634,7 @@
             ]
         },
         "Instance_[1105352460827459]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -7552,7 +7572,7 @@
             ]
         },
         "Instance_[24168316877277]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -7582,7 +7602,7 @@
             ]
         },
         "Instance_[24275691059677]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -7612,7 +7632,7 @@
             ]
         },
         "Instance_[24301460863453]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -11882,7 +11902,7 @@
             ]
         },
         "Instance_[2589848607934200]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -13806,7 +13826,7 @@
             ]
         },
         "Instance_[26783951960541]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -14081,7 +14101,7 @@
             ]
         },
         "Instance_[27200563788253]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -14111,7 +14131,7 @@
             ]
         },
         "Instance_[27234923526621]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -14141,7 +14161,7 @@
             ]
         },
         "Instance_[27247808428509]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -14171,7 +14191,7 @@
             ]
         },
         "Instance_[27260693330397]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -14201,7 +14221,7 @@
             ]
         },
         "Instance_[27273578232285]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15696,7 +15716,7 @@
             ]
         },
         "Instance_[35214746578625]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15926,7 +15946,7 @@
             ]
         },
         "Instance_[363335537380539]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -15966,7 +15986,7 @@
             ]
         },
         "Instance_[363339832347835]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -16006,7 +16026,7 @@
             ]
         },
         "Instance_[363344127315131]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -19369,7 +19389,7 @@
             ]
         },
         "Instance_[43699776244923]": {
-            "Source": "AgPlatform/agplatform.prefab",
+            "Source": "AgPlatform/AgPlatform.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47308,7 +47328,7 @@
             ]
         },
         "Instance_[87613573773789]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47393,7 +47413,7 @@
             ]
         },
         "Instance_[87643638544861]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47428,7 +47448,7 @@
             ]
         },
         "Instance_[87656523446749]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47513,7 +47533,7 @@
             ]
         },
         "Instance_[87669408348637]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47548,7 +47568,7 @@
             ]
         },
         "Instance_[87682293250525]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47583,7 +47603,7 @@
             ]
         },
         "Instance_[87695178152413]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47618,7 +47638,7 @@
             ]
         },
         "Instance_[87708063054301]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47703,7 +47723,7 @@
             ]
         },
         "Instance_[87720947956189]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47738,7 +47758,7 @@
             ]
         },
         "Instance_[87733832858077]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47773,7 +47793,7 @@
             ]
         },
         "Instance_[87746717759965]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47858,7 +47878,7 @@
             ]
         },
         "Instance_[87759602661853]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47893,7 +47913,7 @@
             ]
         },
         "Instance_[87772487563741]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47928,7 +47948,7 @@
             ]
         },
         "Instance_[87785372465629]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -47998,7 +48018,7 @@
             ]
         },
         "Instance_[87836912073181]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -48038,7 +48058,7 @@
             ]
         },
         "Instance_[87849796975069]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -48078,7 +48098,7 @@
             ]
         },
         "Instance_[87862681876957]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -48118,7 +48138,7 @@
             ]
         },
         "Instance_[87875566778845]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -48158,7 +48178,7 @@
             ]
         },
         "Instance_[87888451680733]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",
@@ -48198,7 +48218,7 @@
             ]
         },
         "Instance_[87901336582621]": {
-            "Source": "LECstraight/lecstraight.prefab",
+            "Source": "LECstraight/LECstraight.prefab",
             "Patches": [
                 {
                     "op": "replace",

--- a/Prefabs/Teleporter0.prefab
+++ b/Prefabs/Teleporter0.prefab
@@ -198,6 +198,10 @@
                         "Destination": "Entity_[59349873378397]"
                     }
                 },
+                "Component_[741486691161590945]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 741486691161590945
+                },
                 "Component_[9083664918289908248]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 9083664918289908248


### PR DESCRIPTION
1. There were a bunch of prefab instances in the level that had the wrong mixed-case names for their prefabs. These have been fixed up.
2. Ran the Static Rigid Body cvar command to add Static Rigid Body components to all the entities in prefabs that were missing them.