### PR TITLE
Partial fix for the network teleporter

### DIFF
--- a/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
@@ -43,16 +43,32 @@ namespace MultiplayerSample
     {
     }
 
-    void NetworkTeleportComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    void NetworkTeleportComponentController::OnPhysicsEnabled(const AZ::EntityId& entityId)
     {
         auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
         if (physicsSystem)
         {
-            const AZ::EntityId selfId = GetEntity()->GetId();
-            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(selfId);
+            auto [sceneHandle, bodyHandle] = physicsSystem->FindAttachedBodyHandleFromEntityId(entityId);
             AzPhysics::SimulatedBodyEvents::RegisterOnTriggerEnterHandler(
                 sceneHandle, bodyHandle, m_enterTrigger);
         }
+    }
+
+    void NetworkTeleportComponentController::OnPhysicsDisabled([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        m_enterTrigger.Disconnect();
+    }
+
+
+    void NetworkTeleportComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntity()->GetId());
+    }
+
+    void NetworkTeleportComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+        m_enterTrigger.Disconnect();
     }
 
     void NetworkTeleportComponentController::OnTriggerEnter(

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.h
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.h
@@ -10,6 +10,7 @@
 #include <Source/AutoGen/NetworkTeleportComponent.AutoComponent.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 
 namespace MultiplayerSample
 {
@@ -33,14 +34,18 @@ namespace MultiplayerSample
 
     class NetworkTeleportComponentController
         : public NetworkTeleportComponentControllerBase
+        , private Physics::RigidBodyNotificationBus::Handler
     {
     public:
         NetworkTeleportComponentController(NetworkTeleportComponent& parent);
 
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
-        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override {};
+        void OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     private:
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
+        void OnPhysicsDisabled(const AZ::EntityId& entityId) override;
+
         AzPhysics::SimulatedBodyEvents::OnTriggerEnter::Handler m_enterTrigger;
         void OnTriggerEnter(
             AzPhysics::SimulatedBodyHandle bodyHandle, const AzPhysics::TriggerEvent& triggerEvent);


### PR DESCRIPTION
With the recent Static Rigid Body changes, the Network Teleporter code needed to change to listen for "OnPhysicsEnabled" instead of "OnActivated" to successfully register the trigger event.

However, this is only listed as a "partial fix" because there are still some cases in which the player can land on the trigger volume without triggering the event. This appears like it might be related to how the player walking physics is implemented - it might be that the player is floating just high enough above the volume sometimes that it doesn't actually enter it.