### PR TITLE
Fixed seed list and server.cfg

### DIFF
--- a/AssetBundling/SeedLists/BasePopcornFxSeedList.seed
+++ b/AssetBundling/SeedLists/BasePopcornFxSeedList.seed
@@ -216,6 +216,14 @@
 			<Class name="unsigned int" field="platformFlags" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="shaders/ribbon/legacy/ribbonlitcorrectdeformation_legacy.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{83F58ABC-88B1-5800-ABBA-3DEBB1BDA33F}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/distortionpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
 	</Class>
 </ObjectStream>
 

--- a/server.cfg
+++ b/server.cfg
@@ -1,3 +1,2 @@
 r_displayInfo 3
-host
 LoadLevel Levels/NewStarbase/NewStarbase.spawnable


### PR DESCRIPTION
Seed list - added new shader from the PopcornFX update. Without it, client pak builds would crash.
Server.cfg - removed "host" command. It's redundant with the latest development changes since servers auto-host and it will trigger a warning.