### PR TITLE
Remove net_UdpTimeoutConnections=false from game.cfg

### DIFF
--- a/game.cfg
+++ b/game.cfg
@@ -1,7 +1,6 @@
 sys_game_name = "MultiplayerSample"
 sys_localization_folder = Localization
 ca_useIMG_CAF = 0
-net_UdpTimeoutConnections = false
 
 -- Enable warnings when asset loads take longer than the given millisecond threshold
 cl_assetLoadWarningEnable=true


### PR DESCRIPTION
Remove .cfg command which disabled UDP timeouts, which was causing the server to indefinitely hold on to client connections.

## Testing

1. ran server and client launchers locally, reproduced persistent client connection after close with current settings
2. removed `net_UdpTimeoutConnections=false` from game.cfg
3. re-ran server and client launchers, closed client, observed connection timeout and close in Server.log