### PR TITLE
Prevent crashes when too many shots are added to TraceWeapon.

### DIFF
--- a/Gem/Code/Source/Weapons/TraceWeapon.cpp
+++ b/Gem/Code/Source/Weapons/TraceWeapon.cpp
@@ -33,7 +33,14 @@ namespace MultiplayerSample
             if (isMultiSegmented)
             {
                 ActiveShot activeShot{ eventData.m_initialTransform, eventData.m_targetPosition, LifetimeSec{ 0.0f } };
-                weaponState.m_activeShots.emplace_back(activeShot);
+                if (weaponState.m_activeShots.size() < weaponState.m_activeShots.max_size())
+                { 
+                    weaponState.m_activeShots.emplace_back(activeShot);
+                }
+                else
+                {
+                    AZ_Assert(false, "Attempting to add too many active shots to the TraceWeapon.");
+                }
             }
             else if (GatherEntities(eventData, gatherResults))
             {


### PR DESCRIPTION
The root cause of this still needs to get fixed but this will likely prevent some number of crashes while waiting for a proper fix.

In general, this is occurring because shots from other players are getting added to the activeShots list, but they're never updated / ticked, so they never get removed. After 32 shots, this list overflows. At that point, it's a little unclear as to whether or not this would start overwriting random memory, but at a minimum it leaves the activeShots list in a corrupt state.

This fix ensures that we never add more than 32 shots to the list so we'll never write past the bounds.