### PR TITLE
Remove gem collisions

### DIFF
--- a/Prefabs/Blue_Gem.prefab
+++ b/Prefabs/Blue_Gem.prefab
@@ -157,6 +157,7 @@
                     "Id": 4709323619022222983,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,

--- a/Prefabs/Diamond_Gem.prefab
+++ b/Prefabs/Diamond_Gem.prefab
@@ -153,6 +153,7 @@
                     "Id": 4709323619022222983,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,

--- a/Prefabs/Gold_Gem.prefab
+++ b/Prefabs/Gold_Gem.prefab
@@ -157,6 +157,7 @@
                     "Id": 4709323619022222983,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,

--- a/Prefabs/Green_Gem.prefab
+++ b/Prefabs/Green_Gem.prefab
@@ -134,6 +134,7 @@
                     "Id": 4709323619022222983,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,

--- a/Prefabs/Red_Gem.prefab
+++ b/Prefabs/Red_Gem.prefab
@@ -161,6 +161,7 @@
                     "Id": 4709323619022222983,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "InSceneQueries": false,
                         "Position": [
                             0.0,
                             0.0,


### PR DESCRIPTION
This leaves the Gem Colliders as Trigger Volumes, but removes them from Scene Queries so that they don't actively collide with the camera and make the camera pop. Players can still collect the Gems because the triggers still work.

