### PR TITLE
Hopefully fix the disappearing gem problem

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -191,12 +191,8 @@ namespace MultiplayerSample
 
             if (netEntityHandle.Exists())
             {
-                // Currently blocked by https://github.com/o3de/o3de/issues/11695
-                /*AZ::EntityBus::MultiHandler::BusConnect(gem.first);
-                Multiplayer::GetNetworkEntityManager()->MarkForRemoval(netEntityHandle);*/
-
-                // Until https://github.com/o3de/o3de/issues/11695 is fixed, move the gem out of the view
-                AZ::TransformBus::Event(gem.first, &AZ::TransformBus::Events::SetWorldTranslation, AZ::Vector3::CreateAxisZ(-1000.f));
+                AZ::EntityBus::MultiHandler::BusConnect(gem.first);
+                Multiplayer::GetNetworkEntityManager()->MarkForRemoval(netEntityHandle);
 
                 m_queuedForRemovalGems.emplace(gem.first, gem.second);
             }

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -194,6 +194,9 @@ namespace MultiplayerSample
                 AZ::EntityBus::MultiHandler::BusConnect(gem.first);
                 Multiplayer::GetNetworkEntityManager()->MarkForRemoval(netEntityHandle);
 
+                // Move the gem out of the view because it can take a little while before the removal gets applied.
+                AZ::TransformBus::Event(gem.first, &AZ::TransformBus::Events::SetWorldTranslation, AZ::Vector3::CreateAxisZ(-1000.f));
+
                 m_queuedForRemovalGems.emplace(gem.first, gem.second);
             }
         }


### PR DESCRIPTION
When people connect & disconnect to the MPS, eventually all the gems disappear, even though they can still get picked up. This _seems_ like it's related to the round start handling of gems. The code moves all the existing gems and spawns new ones, but never cleans up the old ones. This PR adds back in the entity removal code, which appears like it was temporarily commented out until a GHI was resolved, but it's since been resolved.