### PR TITLE
Weapon firing fixes on simulated clients

### DIFF
--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -75,6 +75,8 @@ namespace MultiplayerSample
             ActivationCountsAddEvent(m_activationCountHandler);
         }
 
+        m_tickSimulatedWeapons.Enqueue(AZ::Time::ZeroTimeMs);
+
 #if AZ_TRAIT_CLIENT
         if (m_debugDraw == nullptr)
         {
@@ -85,7 +87,7 @@ namespace MultiplayerSample
 
     void NetworkWeaponsComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        ;
+        m_tickSimulatedWeapons.RemoveFromQueue();
     }
 
 #if AZ_TRAIT_CLIENT
@@ -316,6 +318,17 @@ namespace MultiplayerSample
         }
     }
 
+
+    void NetworkWeaponsComponent::OnTickSimulatedWeapons(float seconds)
+    {
+        for (int weaponIndex = 0; weaponIndex < m_simulatedWeaponStates.size(); ++weaponIndex)
+        {
+            if (auto* weapon = GetWeapon(static_cast<WeaponIndex>(weaponIndex)))
+            {
+                weapon->TickActiveShots(m_simulatedWeaponStates[weaponIndex], seconds);
+            }
+        }
+    }
 
     NetworkWeaponsComponentController::NetworkWeaponsComponentController(NetworkWeaponsComponent& parent)
         : NetworkWeaponsComponentControllerBase(parent)

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.h
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.h
@@ -85,7 +85,7 @@ namespace MultiplayerSample
         AZ::ScheduledEvent m_tickSimulatedWeapons{[this]()
         {
             OnTickSimulatedWeapons(AZ::TimeMsToSeconds(m_tickSimulatedWeapons.TimeInQueueMs()));
-        }, AZ::Name("TickSimualtedWeapons")};
+        }, AZ::Name("TickSimulatedWeapons")};
     };
 
     class NetworkWeaponsComponentController

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.h
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.h
@@ -67,6 +67,7 @@ namespace MultiplayerSample
         void OnWeaponConfirmHit(const WeaponHitInfo& hitInfo);
 
         void OnUpdateActivationCounts(int32_t index, uint8_t value);
+        void OnTickSimulatedWeapons(float seconds);
 
         using WeaponPointer = AZStd::unique_ptr<IWeapon>;
         AZStd::array<WeaponPointer, MaxWeaponsPerComponent> m_weapons;
@@ -81,7 +82,6 @@ namespace MultiplayerSample
         OnWeaponPredictHitEvent m_onWeaponPredictHitEvent;
         OnWeaponConfirmHitEvent m_onWeaponConfirmHitEvent;
 
-        void OnTickSimulatedWeapons(float seconds);
         AZ::ScheduledEvent m_tickSimulatedWeapons{[this]()
         {
             OnTickSimulatedWeapons(AZ::TimeMsToSeconds(m_tickSimulatedWeapons.TimeInQueueMs()));

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.h
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.h
@@ -80,6 +80,12 @@ namespace MultiplayerSample
         OnWeaponActivateEvent m_onWeaponActivateEvent;
         OnWeaponPredictHitEvent m_onWeaponPredictHitEvent;
         OnWeaponConfirmHitEvent m_onWeaponConfirmHitEvent;
+
+        void OnTickSimulatedWeapons(float seconds);
+        AZ::ScheduledEvent m_tickSimulatedWeapons{[this]()
+        {
+            OnTickSimulatedWeapons(AZ::TimeMsToSeconds(m_tickSimulatedWeapons.TimeInQueueMs()));
+        }, AZ::Name("TickSimualtedWeapons")};
     };
 
     class NetworkWeaponsComponentController


### PR DESCRIPTION
This resolves the issue of not seeing weapons of other clients. Or those weapons not hitting.