### PR TITLE
Added a hit volume without affecting player movement

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.cpp
@@ -68,6 +68,10 @@ namespace MultiplayerSample
 
     void WeaponEffectComponent::OnWeaponActivate(const WeaponActivationInfo& info)
     {
+        const AZ::Vector3& hitCenter = info.m_activateEvent.m_targetPosition;
+        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
+            SoundEffect::LaserPistolImpact, hitCenter);
+
         // This is the locally predicated effect on the player that initiated the weapon.
         const AZ::Vector3 start = GetNetworkWeaponsComponent()->GetCurrentShotStartPosition();
         const AZ::Vector3& end = info.m_activateEvent.m_targetPosition;
@@ -76,9 +80,6 @@ namespace MultiplayerSample
 
     void WeaponEffectComponent::OnWeaponConfirmHit([[maybe_unused]] const WeaponHitInfo& info)
     {
-        const AZ::Vector3& hitCenter = info.m_hitEvent.m_hitTransform.GetTranslation();
-        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
-            SoundEffect::LaserPistolImpact, hitCenter);
     }
 
 

--- a/Prefabs/Player.prefab
+++ b/Prefabs/Player.prefab
@@ -115,6 +115,9 @@
                     "Id": 14925070260434397195,
                     "Configuration": {
                         "entityId": "",
+                        "CollisionGroupId": {
+                            "GroupId": "{FE20AF05-2602-45C6-BF4D-FA497B971061}"
+                        },
                         "MaterialSlots": {
                             "Slots": [
                                 {
@@ -460,8 +463,7 @@
                         "loadBehavior": "QueueLoad",
                         "assetHint": "mixamo/ybot/ybot.actor"
                     },
-                    "AttachmentTarget": "",
-                    "RenderSkeleton": true
+                    "AttachmentTarget": ""
                 },
                 "Component_[5387953310772448141]": {
                     "$type": "GenericComponentWrapper",

--- a/Registry/physxsystemconfiguration.setreg
+++ b/Registry/physxsystemconfiguration.setreg
@@ -8,7 +8,7 @@
                             "LayerNames": [
                                 "Default",
                                 "HitVolumes",
-                                "CharacterBodies",
+                                {},
                                 {},
                                 {},
                                 {},

--- a/Registry/physxsystemconfiguration.setreg
+++ b/Registry/physxsystemconfiguration.setreg
@@ -7,8 +7,8 @@
                         "Layers": {
                             "LayerNames": [
                                 "Default",
-                                {},
-                                {},
+                                "HitVolumes",
+                                "CharacterBodies",
                                 {},
                                 {},
                                 {},
@@ -97,6 +97,15 @@
                                         "Mask": 9223372036854775807
                                     },
                                     "ReadOnly": true
+                                },
+                                {
+                                    "Id": {
+                                        "GroupId": "{FE20AF05-2602-45C6-BF4D-FA497B971061}"
+                                    },
+                                    "Name": "AllButHitVolumes",
+                                    "Group": {
+                                        "Mask": 18446744073709551613
+                                    }
                                 }
                             ]
                         }


### PR DESCRIPTION
- Adds a single hit volume for the main body (once this is tested I can add more precise hit volumes)
- Hit volumes are marked as `HitVolumes` collision layer
![image](https://user-images.githubusercontent.com/5432499/221318860-d74457cf-35f0-4714-80e5-9e570cf1c043.png)
![image](https://user-images.githubusercontent.com/5432499/221318799-8f2b14a4-8b86-47b8-ad9d-9a594cb1df10.png)
![image](https://user-images.githubusercontent.com/5432499/221319546-f6f57e40-dcea-439b-960e-50f508c6185b.png)
![image](https://user-images.githubusercontent.com/5432499/221314089-f13c6ce5-4b5a-45fd-b50d-560ed0d7015b.png)

- Moved weapon sounds to activation without requiring confirmed hits (this avoids multiple sound effects for a single shot)
- Turned off debug skeleton view on actors
- Player character bodies are marked to use `AllButHitVolumes` collision group
![image](https://user-images.githubusercontent.com/5432499/221318926-f7226f44-675a-469e-94df-47042311e127.png)


