### PR TITLE
Fix project not appearing in Visual Studio Solution

### DIFF
--- a/project.json
+++ b/project.json
@@ -13,7 +13,9 @@
     ],
     "icon_path": "preview.png",
     "engine": "o3de",
-    "external_subdirectories": [],
+    "external_subdirectories": [
+        "Gem"
+    ],
     "gem_names": [
         "character_mps",
         "props_mps",
@@ -23,6 +25,5 @@
         "particlefx_mps",
         "pbr_material_pack_mps",
         "PopcornFX"
-    ],
-    "engine_version": "1.0.0"
+    ]
 }


### PR DESCRIPTION
MultiplayerSample Gem Project was missing from Visual Studio because my recent `EngineFinder.cmake` changes somehow caused the Gem not to be found and the external subdirectory not to get added.  New projects include that using the `project.json` `external_subdirectories` field.
- add missing "Gem" entry in project.json
- removed unused/invalid old `engine_version` field I must have accidentally committed at some point.  Engine version dependencies do not use this field, they use the `engine` so if we wanted to tie the project to a specific version of o3de (which we don't) we would use `"engine":"o3de==1.0.0"` 
After this change the Solution contains the gem again:
![image](https://user-images.githubusercontent.com/26804013/221753483-7cbb9909-cff2-42c9-b455-74be96576f9c.png)

