### PR TITLE
Fix some MPS audio issues

### DIFF
--- a/Gem/Code/Include/GameplayEffectsNotificationBus.h
+++ b/Gem/Code/Include/GameplayEffectsNotificationBus.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Math/Vector3.h>
 
@@ -42,15 +43,16 @@ namespace MultiplayerSample
         BubbleGunProjectile,
         BubbleGunImpact,
 
-        // Jump Pad
+        // Environment
         JumpPadLaunch,
+        TeleporterUse,
 
         // Energy Ball Trap
         EnergyBallTrapRisingOutOfTheGround,
         EnergyBallTrapBuildup, // followed by muzzle flash
         EnergyBallTrapProjectile,
         EnergyBallTrapImpact,
-        EnergyBallTrapOnCooldown, // plays when you try to fire it during cooldown
+        EnergyBallTrapOnCooldown // plays when you try to fire it during cooldown
     );
 
     class GameplayEffectsNotifications : public AZ::EBusTraits

--- a/Gem/Code/Source/AutoGen/GameplayEffectsComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/GameplayEffectsComponent.AutoComponent.xml
@@ -38,8 +38,9 @@
 	<ArchetypeProperty Type="AZStd::string" Name="BubbleGunMuzzleFlash" ExposeToEditor="true" Description="Audio trigger name" />
 	<ArchetypeProperty Type="AZStd::string" Name="BubbleGunProjectile" ExposeToEditor="true" Description="Audio trigger name" />
 	<ArchetypeProperty Type="AZStd::string" Name="BubbleGunImpact" ExposeToEditor="true" Description="Audio trigger name" />
-	<!-- Jump Pad -->
+	<!-- Environment -->
 	<ArchetypeProperty Type="AZStd::string" Name="JumpPadLaunch" ExposeToEditor="true" Description="Audio trigger name" />
+	<ArchetypeProperty Type="AZStd::string" Name="TeleporterUse" ExposeToEditor="true" Description="Audio trigger name" />
 	<!-- Energy Ball Trap -->
 	<ArchetypeProperty Type="AZStd::string" Name="EnergyBallTrapRisingOutOfTheGround" ExposeToEditor="true" Description="Audio trigger name" />
 	<ArchetypeProperty Type="AZStd::string" Name="EnergyBallTrapBuildup" ExposeToEditor="true" Description="Audio trigger name" />

--- a/Gem/Code/Source/Components/Multiplayer/GameplayEffectsComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GameplayEffectsComponent.cpp
@@ -64,6 +64,7 @@ namespace MultiplayerSample
         m_soundTriggerNames[aznumeric_cast<int>(SoundEffect::BubbleGunImpact)] = GetBubbleGunImpact();
 
         m_soundTriggerNames[aznumeric_cast<int>(SoundEffect::JumpPadLaunch)] = GetJumpPadLaunch();
+        m_soundTriggerNames[aznumeric_cast<int>(SoundEffect::TeleporterUse)] = GetTeleporterUse();
 
         m_soundTriggerNames[aznumeric_cast<int>(SoundEffect::EnergyBallTrapRisingOutOfTheGround)] = GetEnergyBallTrapRisingOutOfTheGround();
         m_soundTriggerNames[aznumeric_cast<int>(SoundEffect::EnergyBallTrapBuildup)] = GetEnergyBallTrapBuildup();

--- a/Gem/Code/Source/Components/Multiplayer/PlayerCoinCollectorComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerCoinCollectorComponent.cpp
@@ -72,12 +72,9 @@ namespace MultiplayerSample
                     {
                         if (GemComponent* gem = coinEntity->FindComponent<GemComponent>())
                         {
-                            GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
-                                SoundEffect::GemPickup, GetEntity()->GetTransform()->GetWorldTranslation());
-
                             gem->RPC_CollectedByPlayer();
                             ModifyCoinsCollected() += gem->GetGemScoreValue();
-                            PlayerCoinCollectorNotificationBus::Broadcast(&PlayerCoinCollectorNotifications::OnPlayerCollectedCoinCountChanged, 
+                            PlayerCoinCollectorNotificationBus::Broadcast(&PlayerCoinCollectorNotifications::OnPlayerCollectedCoinCountChanged,
                                 GetNetEntityId(), GetCoinsCollected());
                         }
                     }
@@ -90,5 +87,9 @@ namespace MultiplayerSample
     void PlayerCoinCollectorComponentController::OnCoinsChanged(uint16_t coins)
     {
         UiCoinCountNotificationBus::Broadcast(&UiCoinCountNotifications::OnCoinCountChanged, coins);
+#if AZ_TRAIT_CLIENT
+        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
+            SoundEffect::GemPickup, GetEntity()->GetTransform()->GetWorldTranslation());
+#endif
     }
 }

--- a/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/WeaponEffectComponent.cpp
@@ -60,18 +60,16 @@ namespace MultiplayerSample
 
             particle->Restart(true);
         }
-#endif
 
-        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect, 
+        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
             SoundEffect::LaserPistolMuzzleFlash, GetEntity()->GetTransform()->GetWorldTranslation());
+        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
+            SoundEffect::LaserPistolImpact, end);
+#endif
     }
 
     void WeaponEffectComponent::OnWeaponActivate(const WeaponActivationInfo& info)
     {
-        const AZ::Vector3& hitCenter = info.m_activateEvent.m_targetPosition;
-        GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnPositionalEffect,
-            SoundEffect::LaserPistolImpact, hitCenter);
-
         // This is the locally predicated effect on the player that initiated the weapon.
         const AZ::Vector3 start = GetNetworkWeaponsComponent()->GetCurrentShotStartPosition();
         const AZ::Vector3& end = info.m_activateEvent.m_targetPosition;

--- a/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportComponent.cpp
@@ -7,6 +7,7 @@
 
 #include "NetworkTeleportComponent.h"
 
+#include <GameplayEffectsNotificationBus.h>
 #include <Multiplayer/Components/NetworkTransformComponent.h>
 #include <Source/Components/NetworkTeleportCompatibleComponent.h>
 #include <AzCore/Component/TransformBus.h>
@@ -81,6 +82,9 @@ namespace MultiplayerSample
                 teleportLocation.GetX(), teleportLocation.GetY());
 
             AZ::Entity* otherEntity = GetCollidingEntity(triggerEvent.m_otherBody);
+
+            GameplayEffectsNotificationBus::Broadcast(&GameplayEffectsNotificationBus::Events::OnEffect,
+                SoundEffect::TeleporterUse);
             TeleportPlayer(teleportLocation, otherEntity);
         }
     }
@@ -127,7 +131,7 @@ namespace MultiplayerSample
             }
             else
             {
-                AZ_TracePrintf("Teleporter", "colliding entity %s is not teleport compatible! NoOp.\n", 
+                AZ_TracePrintf("Teleporter", "colliding entity %s is not teleport compatible! NoOp.\n",
                     entity->GetName().c_str());
             }
         }

--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -5575,10 +5575,11 @@
                     "Id": 8106850883560113265,
                     "m_template": {
                         "$type": "MultiplayerSample::GameplayEffectsComponent",
-                        "GemPickup": "Play_Gem_Pickup",
+                        "GemPickup": "play_sx_int_gem_pickup",
                         "RoundStart": "Play_Round_Begin",
                         "RoundEnd": "Play_Round_End",
-                        "LaserPistolImpact": "Play_Laser_Gun_Impact",
+                        "LaserPistolMuzzleFlash": "play_sx_wpn_laserpistol_fire",
+                        "LaserPistolImpact": "play_sx_wpn_laserpistol_impact",
                         "EnergyBallTrapImpact": "Play_Laser_Gun_Impact"
                     }
                 },

--- a/Prefabs/GamePlay_Effects.prefab
+++ b/Prefabs/GamePlay_Effects.prefab
@@ -137,6 +137,7 @@
                         "BubbleGunProjectile": "play_sx_wpn_bubblegun_projectile",
                         "BubbleGunImpact": "play_sx_wpn_bubblegun_impact",
                         "JumpPadLaunch": "play_sx_int_jumppad_launch",
+                        "TeleporterUse": "play_sx_int_jumppad_launch",
                         "EnergyBallTrapRisingOutOfTheGround": "play_sx_int_energyballtrap_rising",
                         "EnergyBallTrapBuildup": "play_sx_int_energyballtrap_buildup",
                         "EnergyBallTrapProjectile": "play_sx_int_energyballtrap_projectile",

--- a/Sounds/wwise/MultiplayerSample_SoundBank.bnk
+++ b/Sounds/wwise/MultiplayerSample_SoundBank.bnk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ae5d7c15821f60cded502c84640a416bca255b9f458b707b67e0cdf8b9fba11
-size 20915423
+oid sha256:4dd9433c3d472d2b4b19ef90ebd8868f45ae3a0b528b7ce8cd0c26b021a7e88a
+size 20915589

--- a/Sounds/wwise_project/Events/Default O3DE Work Unit.wwu
+++ b/Sounds/wwise_project/Events/Default O3DE Work Unit.wwu
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WwiseDocument Type="WorkUnit" ID="{6CE550BF-CF71-43E4-985D-8FC19995C3F9}" SchemaVersion="103">
+	<Events>
+		<WorkUnit Name="Default O3DE Work Unit" ID="{6CE550BF-CF71-43E4-985D-8FC19995C3F9}" PersistMode="Standalone">
+			<ChildrenList>
+				<Event Name="mute_all" ID="{61A64DBA-8991-49B9-83B1-AB0B50ECB768}">
+					<ChildrenList>
+						<Action Name="" ID="{57ABCE89-3C19-48E7-B134-3D6D05B9BA8D}" ShortID="277870023">
+							<PropertyList>
+								<Property Name="ActionType" Type="int16" Value="4"/>
+								<Property Name="FadeTime" Type="Real64" Value="0.25"/>
+								<Property Name="Scope" Type="int16" Value="1"/>
+							</PropertyList>
+							<ReferenceList>
+								<Reference Name="Target">
+									<ObjectRef Name="Master Audio Bus" ID="{1514A4D8-1DA6-412A-A17E-75CA0C2149F3}" WorkUnitID="{F62C277B-2C60-43BB-A8B2-F1E94C3F98EC}"/>
+								</Reference>
+							</ReferenceList>
+						</Action>
+					</ChildrenList>
+				</Event>
+				<Event Name="unmute_all" ID="{70A4895C-CCC0-4A20-9EF2-84369B7AB656}">
+					<ChildrenList>
+						<Action Name="" ID="{54D3BDB6-14E8-4FF0-B542-FBE01457392A}" ShortID="412750752">
+							<PropertyList>
+								<Property Name="ActionType" Type="int16" Value="5"/>
+								<Property Name="FadeTime" Type="Real64" Value="0.25"/>
+								<Property Name="Scope" Type="int16" Value="1"/>
+							</PropertyList>
+							<ReferenceList>
+								<Reference Name="Target">
+									<ObjectRef Name="Master Audio Bus" ID="{1514A4D8-1DA6-412A-A17E-75CA0C2149F3}" WorkUnitID="{F62C277B-2C60-43BB-A8B2-F1E94C3F98EC}"/>
+								</Reference>
+							</ReferenceList>
+						</Action>
+					</ChildrenList>
+				</Event>
+				<Event Name="get_focus" ID="{9C546699-874C-4944-921A-3AFA45EA389F}">
+					<ChildrenList>
+						<Action Name="" ID="{7786DCAE-FFA5-4139-99EB-B43AB8996995}" ShortID="300486804">
+							<PropertyList>
+								<Property Name="ActionType" Type="int16" Value="5"/>
+								<Property Name="FadeTime" Type="Real64" Value="0.25"/>
+								<Property Name="Scope" Type="int16" Value="1"/>
+							</PropertyList>
+							<ReferenceList>
+								<Reference Name="Target">
+									<ObjectRef Name="Master Audio Bus" ID="{1514A4D8-1DA6-412A-A17E-75CA0C2149F3}" WorkUnitID="{F62C277B-2C60-43BB-A8B2-F1E94C3F98EC}"/>
+								</Reference>
+							</ReferenceList>
+						</Action>
+					</ChildrenList>
+				</Event>
+				<Event Name="lose_focus" ID="{46F2D4CD-D503-4063-8D3D-A2A0A0E156FF}">
+					<ChildrenList>
+						<Action Name="" ID="{B4C1CFDC-D205-42F4-B487-54098A09EFF9}" ShortID="577708608">
+							<PropertyList>
+								<Property Name="ActionType" Type="int16" Value="4"/>
+								<Property Name="FadeTime" Type="Real64" Value="0.25"/>
+								<Property Name="Scope" Type="int16" Value="1"/>
+							</PropertyList>
+							<ReferenceList>
+								<Reference Name="Target">
+									<ObjectRef Name="Master Audio Bus" ID="{1514A4D8-1DA6-412A-A17E-75CA0C2149F3}" WorkUnitID="{F62C277B-2C60-43BB-A8B2-F1E94C3F98EC}"/>
+								</Reference>
+							</ReferenceList>
+						</Action>
+					</ChildrenList>
+				</Event>
+				<Event Name="do_nothing" ID="{59644E92-2831-425C-ACD3-BF068AAE1F77}"/>
+			</ChildrenList>
+		</WorkUnit>
+	</Events>
+</WwiseDocument>

--- a/Sounds/wwise_project/SoundBanks/Default Work Unit.wwu
+++ b/Sounds/wwise_project/SoundBanks/Default Work Unit.wwu
@@ -6,6 +6,7 @@
 				<SoundBank Name="MultiplayerSample_SoundBank" ID="{177A80C9-E12C-4E27-AAFE-433768DCB2D5}">
 					<ObjectInclusionList>
 						<ObjectRef Name="Play_Gem_Pickup" ID="{71E57F3C-D599-41C4-8809-E1B12C333CD6}" WorkUnitID="{0566E170-B00C-43ED-9207-35F37FE8B969}" Origin="Manual" Filter="7"/>
+						<ObjectRef Name="Default O3DE Work Unit" ID="{6CE550BF-CF71-43E4-985D-8FC19995C3F9}" WorkUnitID="{6CE550BF-CF71-43E4-985D-8FC19995C3F9}" Origin="Manual" Filter="7"/>
 						<ObjectRef Name="AMPS" ID="{9870BD75-84BD-4495-92BC-530D5ADE62D4}" WorkUnitID="{9870BD75-84BD-4495-92BC-530D5ADE62D4}" Origin="Manual" Filter="7"/>
 						<ObjectRef Name="Play_Round_Begin" ID="{D684C934-FF22-44B3-B8FE-5BD601B2CA67}" WorkUnitID="{0566E170-B00C-43ED-9207-35F37FE8B969}" Origin="Manual" Filter="7"/>
 						<ObjectRef Name="Stop_Round_Begin" ID="{875FE9AB-B735-45E4-8A0B-5C07A56FE68C}" WorkUnitID="{0566E170-B00C-43ED-9207-35F37FE8B969}" Origin="Manual" Filter="7"/>

--- a/libs/gameaudio/wwise/default_controls.xml
+++ b/libs/gameaudio/wwise/default_controls.xml
@@ -2,19 +2,19 @@
 	<AudioTriggers>
 		<ATLTrigger atl_name="get_focus">
 			<WwiseEvent wwise_name="get_focus"/>
-        </ATLTrigger>
+		</ATLTrigger>
 		<ATLTrigger atl_name="lose_focus">
 			<WwiseEvent wwise_name="lose_focus"/>
-        </ATLTrigger>
+		</ATLTrigger>
 		<ATLTrigger atl_name="mute_all">
 			<WwiseEvent wwise_name="mute_all"/>
-        </ATLTrigger>
+		</ATLTrigger>
 		<ATLTrigger atl_name="unmute_all">
 			<WwiseEvent wwise_name="unmute_all"/>
-        </ATLTrigger>
+		</ATLTrigger>
 		<ATLTrigger atl_name="do_nothing">
 			<WwiseEvent wwise_name="do_nothing"/>
-        </ATLTrigger>
+		</ATLTrigger>
 	</AudioTriggers>
 	<AudioRtpcs>
 		<ATLRtpc atl_name="object_speed"/>

--- a/libs/gameaudio/wwise/default_controls.xml
+++ b/libs/gameaudio/wwise/default_controls.xml
@@ -1,10 +1,20 @@
 <ATLConfig atl_name="default_controls">
 	<AudioTriggers>
-		<ATLTrigger atl_name="get_focus"/>
-		<ATLTrigger atl_name="lose_focus"/>
-		<ATLTrigger atl_name="mute_all"/>
-		<ATLTrigger atl_name="unmute_all"/>
-		<ATLTrigger atl_name="do_nothing"/>
+		<ATLTrigger atl_name="get_focus">
+			<WwiseEvent wwise_name="get_focus"/>
+        </ATLTrigger>
+		<ATLTrigger atl_name="lose_focus">
+			<WwiseEvent wwise_name="lose_focus"/>
+        </ATLTrigger>
+		<ATLTrigger atl_name="mute_all">
+			<WwiseEvent wwise_name="mute_all"/>
+        </ATLTrigger>
+		<ATLTrigger atl_name="unmute_all">
+			<WwiseEvent wwise_name="unmute_all"/>
+        </ATLTrigger>
+		<ATLTrigger atl_name="do_nothing">
+			<WwiseEvent wwise_name="do_nothing"/>
+        </ATLTrigger>
 	</AudioTriggers>
 	<AudioRtpcs>
 		<ATLRtpc atl_name="object_speed"/>


### PR DESCRIPTION
Fix a few things for MPS.

- Stubbed in sound effect slot for TeleporterUse.  Assigned a jumppad sound for now, but this sound implementation still needs work.  It's not working correctly, likely due to the instant change in location of the player (audio listener).
- Fixed issue of laser weapon fire and impacts playing twice, they weren't restricted to client only.
- Fixed gem pickup sounds so that only the player picking them up should hear them.
- Added the default ATL controls to a new work unit in the Wwise project and updated the sound bank.  If needed you can now execute the "mute_all" or "unmute_all" triggers from the game to help aid testing, for example: `s_ExecuteTrigger mute_all`