### PR TITLE
Gem spawner fixes

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -131,7 +131,7 @@ namespace MultiplayerSample
         const RoundSpawnTable& table = 
             GetSpawnTablesPerRound()[AZStd::min(round, aznumeric_cast<uint16_t>(GetSpawnTablesPerRound().size() - 1))];
 
-        // Move the table data into a working kust where we've done a one-time conversion of tags into CRCs and we can temporarily 
+        // Move the table data into a working list where we've done a one-time conversion of tags into CRCs and we can temporarily 
         // store which tags exist on the entity.
         AZStd::vector<GemSpawnEntry> gemSpawnList;
         gemSpawnList.reserve(table.m_gemWeights.size());

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -120,6 +120,26 @@ namespace MultiplayerSample
         LmbrCentral::TagGlobalRequestBus::EventResult(aggregator, AZ::Crc32(GetGemSpawnTag()),
             &LmbrCentral::TagGlobalRequests::RequestTaggedEntities);
 
+        // If there aren't any spawn tables, don't spawn anything.
+        if (GetSpawnTablesPerRound().empty())
+        {
+            return;
+        }
+
+        // Get the current round's spawn table, or the last defined round as a fallback.
+        const uint16_t round = GetNetworkMatchComponentController()->GetRoundNumber();
+        const RoundSpawnTable& table = 
+            GetSpawnTablesPerRound()[AZStd::min(round, aznumeric_cast<uint16_t>(GetSpawnTablesPerRound().size() - 1))];
+
+        // Move the table data into a working kust where we've done a one-time conversion of tags into CRCs and we can temporarily 
+        // store which tags exist on the entity.
+        AZStd::vector<GemSpawnEntry> gemSpawnList;
+        gemSpawnList.reserve(table.m_gemWeights.size());
+        for (const GemWeightChance& gemWeight : table.m_gemWeights)
+        {
+            gemSpawnList.emplace_back(AZ::Crc32(gemWeight.m_tag), gemWeight.m_weight, false);
+        }
+
         for (const AZ::EntityId gemSpawnEntity : aggregator.values)
         {
             // Collect the gem tags for this specific entity.
@@ -128,11 +148,15 @@ namespace MultiplayerSample
                 &LmbrCentral::TagComponentRequestBus::Events::GetTags);
 
             // Randomly select a gem type for this entity.
-            const AZ::Crc32 type = ChooseGemType(tags);
+            const AZ::Crc32 type = ChooseGemType(gemSpawnList, tags);
 
-            AZ::Vector3 position = AZ::Vector3::CreateZero();
-            AZ::TransformBus::EventResult(position, gemSpawnEntity, &AZ::TransformBus::Events::GetWorldTranslation);
-            SpawnGem(position, type);
+            // If this entity has a valid gem type, spawn it.
+            if (type != AZ::Crc32(0))
+            {
+                AZ::Vector3 position = AZ::Vector3::CreateZero();
+                AZ::TransformBus::EventResult(position, gemSpawnEntity, &AZ::TransformBus::Events::GetWorldTranslation);
+                SpawnGem(position, type);
+            }
         }
     }
 
@@ -211,60 +235,42 @@ namespace MultiplayerSample
         m_queuedForRemovalGems.erase(entityId);
     }
 
-    AZ::Crc32 GemSpawnerComponentController::ChooseGemType(const LmbrCentral::Tags& tags)
+    AZ::Crc32 GemSpawnerComponentController::ChooseGemType(AZStd::vector<GemSpawnEntry>& gemSpawnList, const LmbrCentral::Tags& tags)
     {
-        if (GetSpawnTablesPerRound().empty())
-        {
-            return {};
-        }
-
-        // Get the current round's spawn table, or the last defined round as a fallback.
-        const uint16_t round = GetNetworkMatchComponentController()->GetRoundNumber();
-        const RoundSpawnTable* table;
-        if (round < GetSpawnTablesPerRound().size())
-        {
-            table = &GetSpawnTablesPerRound()[round];
-        }
-        else
-        {
-            table = &GetSpawnTablesPerRound().back();
-        }
-
         // Calculate the total weight of all applicable gem tags.
         float totalWeight = 0.f;
-        for (const GemWeightChance& gemWeight : table->m_gemWeights)
+        for (GemSpawnEntry& entry : gemSpawnList)
         {
-            const auto tagIterator = tags.find(AZ::Crc32(gemWeight.m_tag));
+            const auto tagIterator = tags.find(entry.m_tag);
+            entry.m_entityHasTag = tagIterator != tags.end();
             if (tagIterator != tags.end())
             {
-                totalWeight += gemWeight.m_weight;
+                totalWeight += entry.m_weight;
             }
         }
         
         // Create a random float in the range of [0, totalWeight)
         float randomWeight = GetNetworkRandomComponentController()->GetRandomFloat() * totalWeight;
 
-        AZ::Crc32 chosenType(table->m_gemWeights.front().m_tag);
-        for (const GemWeightChance& gemWeight : table->m_gemWeights)
+        AZ::Crc32 chosenType;
+        for (GemSpawnEntry& entry : gemSpawnList)
         {
-            const auto tagIterator = tags.find(AZ::Crc32(gemWeight.m_tag));
-            if (tagIterator == tags.end())
+            if (entry.m_entityHasTag)
             {
-                continue;
-            }
+                // For every acceptable tag, reduce the the weight value until the right gem type is found for the random value.
+                // >----------------------\
+                //                        |
+                // gem1--------gem2-------*--gem3------
+                if (randomWeight > entry.m_weight)
+                {
+                    randomWeight -= entry.m_weight;
+                }
+                else
+                {
+                    chosenType = entry.m_tag;
+                    break;
+                }
 
-            // For every acceptable tag, reduce the the weight value until the right gem type is found for the random value.
-            // >----------------------\
-            //                        |
-            // gem1--------gem2-------*--gem3------
-            if (randomWeight > gemWeight.m_weight)
-            {
-                randomWeight -= gemWeight.m_weight;
-            }
-            else
-            {
-                chosenType = AZ::Crc32(gemWeight.m_tag);
-                break;
             }
         }
 

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
@@ -54,7 +54,19 @@ namespace MultiplayerSample
         AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<AzFramework::EntitySpawnTicket>> m_spawnedGems;
         AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<AzFramework::EntitySpawnTicket>> m_queuedForRemovalGems;
 
+        struct GemSpawnEntry
+        {
+            AZ::Crc32 m_tag;
+            float m_weight;
+            bool m_entityHasTag;
+
+            GemSpawnEntry(AZ::Crc32 tag, float weight, bool entityHasTag)
+                : m_tag(tag), m_weight(weight), m_entityHasTag(entityHasTag)
+            {
+            }
+        };
+
         //! Randomly choose a gem type from the given set of weights for the current round.
-        AZ::Crc32 ChooseGemType(const LmbrCentral::Tags& tags);
+        AZ::Crc32 ChooseGemType(AZStd::vector<GemSpawnEntry>& gemSpawnList, const LmbrCentral::Tags& tags);
     };
 }

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -261,8 +261,17 @@ namespace MultiplayerSample
 #if AZ_TRAIT_SERVER
     void NetworkMatchComponentController::EndRound()
     {
-        ModifyRoundNumber()++;
-        SetRoundTime(RoundTimeSec{ GetRoundDuration() });
+        uint16_t roundNumber = GetRoundNumber() + 1;
+
+        // We need to do this whether or not we're going beyond the number of total rounds so that
+        // the game state code can detect that it's time to end the game.
+        SetRoundNumber(roundNumber);
+
+        if (roundNumber <= GetTotalRounds())
+        {
+            SetRoundTime(RoundTimeSec{ GetRoundDuration() });
+            GetGemSpawnerComponentController()->SpawnGems();
+        }
     }
 
     void NetworkMatchComponentController::HandleRPC_PlayerActivated([[maybe_unused]] AzNetworking::IConnection* invokingConnection,


### PR DESCRIPTION
This fixes a few problems with gem spawning:
* Gems will now only spawn if they have a tag that matches the current round. Previously, if a gem spawner didn't match a tag, they would spawn the first gem in the round's list.
* Optimized the gem spawning code a bit. It was doing a LOT of redundant string to CRC calculations and unordered_set lookups.
* Made gems respawn every round, not just every match. This makes the gem round spawn table a whole lot more useful, since more than just the first round is used now. :)

I briefly tried to fix the "Round 4 of 3" display at the end of the match by not incrementing to round 4, but it turns out the game state logic is relying on that, so I've left that bug alone for the moment.

NOTE: The current checked-in level has a mismatch between spawner tags and spawn table entries ("Yellow Gem" vs "Gold Gem", "Green Gems" vs "Green Gem"), so very few gems will actually appear until those get fixed in a subsequent PR.