### PR TITLE
Gem despawn fixes

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
@@ -28,7 +28,6 @@ namespace MultiplayerSample
 
     class GemSpawnerComponentController
         : public GemSpawnerComponentControllerBase
-        , public AZ::EntityBus::MultiHandler
     {
     public:
         explicit GemSpawnerComponentController(GemSpawnerComponent& parent);
@@ -40,19 +39,13 @@ namespace MultiplayerSample
         void SpawnGems();
 #endif
 
-        //! EntityBus
-        //! @{
-        void OnEntityDeactivated(const AZ::EntityId& entityId) override;
-        //! @}
-
     private:
 #if AZ_TRAIT_SERVER
         void SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type);
         void RemoveGems();
 #endif
 
-        AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<AzFramework::EntitySpawnTicket>> m_spawnedGems;
-        AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<AzFramework::EntitySpawnTicket>> m_queuedForRemovalGems;
+        AZStd::vector<AZStd::pair<AZStd::shared_ptr<AzFramework::EntitySpawnTicket>, AZ::EntityId>> m_spawnedGems;
 
         struct GemSpawnEntry
         {


### PR DESCRIPTION
The existing code caused various types of entity leaks and memory corruption due to the removal of a single entity from a prefab through entity destruction APIs and not through the prefab APIs. This changes the code to use the prefab API to despawn all the entities, which fixes both the problems of entity leaks and corrupted tickets.

Entity leaks: Every prefab has at least 2 entities - a container entity and the main entity. Our gem prefabs currently have 3 entities. Because the code was only destroying the entity with the GemComponent on it, the other 2 entities weren't getting destroyed and were slowly accumulating.

Ticket corruption: The prefab system expects to own the entities unless the ClaimEntities() API is called. When it tried to destroy the ticket and despawn the entities, it had a corrupted state that kept these requests queued permanently. It's _likely_ (but unproven) that if memory happened to contain the correct values in it, the requests would actually process and crash. If the requests didn't process, then they would also continue to accumulate every time gems were despawned.

All of this was visible in code by placing breakpoints in SpawnableEntitiesManager::ProcessQueue anywhere that entries could get requeued due to not being processed. If the breakpoints trip when running MPS, then the invalid entries have been added.

With the fix below, along with the companion fix in https://github.com/o3de/o3de/pull/14937 , the breakpoints no longer trip, and gems continue to spawn and despawn as expected when running the client.