### PR TITLE
Stop Player Movement Between Rounds

### DIFF
--- a/Gem/Code/Source/Components/NetworkMatchComponent.h
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.h
@@ -26,6 +26,11 @@ namespace MultiplayerSample
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
+        //! Checks if the current game state allows player action.
+        //! For example, in between rounds the player shouldn't be able to move around.
+        //! @result true if the player is currently allowed to run, jump, shoot, etc; otherwise false.
+        bool IsPlayerActionAllowed() const;
+
 #if AZ_TRAIT_SERVER
         //! PlayerIdentityNotificationBus
         //! @{

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -25,7 +25,6 @@
 #include <PhysX/CharacterGameplayBus.h>
 #include <PhysX/CharacterControllerBus.h>
 
-#pragma optimize("", off)
 namespace MultiplayerSample
 {
     AZ_CVAR(float, cl_WasdStickAccel, 5.0f, nullptr, AZ::ConsoleFunctorFlags::Null, "The linear acceleration to apply to WASD inputs to simulate analog stick controls");
@@ -674,4 +673,3 @@ namespace MultiplayerSample
     }
 #endif
 } // namespace MultiplayerSample
-#pragma optimize("", on)

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -140,7 +140,7 @@ namespace MultiplayerSample
             m_crouching = false;
 
             // Don't set m_forward/left/right/backDown to 0, instead just 0 out the net-input by hand.
-            // This way player's can start the round hot out the gate.
+            // This way players can start the round hot out of the gate.
             // Keep their finger on the 'W' (forward) key, and instantly start
             // running when the round starts instead of having to release the 'W' key and pressing it again.
             playerInput->m_forwardAxis = StickAxis(0);

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.h
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.h
@@ -65,8 +65,6 @@ namespace MultiplayerSample
         void OnHeld(float value) override;
         //! @}
 
-        bool ShouldProcessInput() const;
-
 #if AZ_TRAIT_SERVER
         void UpdateAI();
         AZ::ScheduledEvent m_updateAI;

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -11,13 +11,12 @@
 #include <Source/Components/NetworkAnimationComponent.h>
 #include <Source/Components/NetworkHealthComponent.h>
 #include <Multiplayer/Components/NetworkRigidBodyComponent.h>
+#include <Source/Components/NetworkMatchComponent.h>
 #include <Source/Components/NetworkSimplePlayerCameraComponent.h>
 #include <Source/Weapons/BaseWeapon.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
-#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
-#include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 
 #if AZ_TRAIT_CLIENT
 #include <DebugDraw/DebugDrawBus.h>
@@ -364,15 +363,6 @@ namespace MultiplayerSample
         }
     }
 
-    bool NetworkWeaponsComponentController::ShouldProcessInput() const
-    {
-        AzFramework::SystemCursorState systemCursorState{AzFramework::SystemCursorState::Unknown};
-        AzFramework::InputSystemCursorRequestBus::EventResult( systemCursorState, AzFramework::InputDeviceMouse::Id,
-            &AzFramework::InputSystemCursorRequests::GetSystemCursorState);
-
-        // only process input when the system cursor isn't unconstrainted and visible a.k.a console mode
-        return systemCursorState != AzFramework::SystemCursorState::UnconstrainedAndVisible;
-    }
 
     AZ::Vector3 NetworkWeaponsComponent::GetCurrentShotStartPosition()
     {
@@ -390,7 +380,7 @@ namespace MultiplayerSample
 
     void NetworkWeaponsComponentController::CreateInput(Multiplayer::NetworkInput& input, [[maybe_unused]] float deltaTime)
     {
-        if (!ShouldProcessInput())
+        if (!AZ::Interface<NetworkMatchComponent>::Get()->IsPlayerActionAllowed())
         {
             m_weaponFiring = false;
             return;

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.h
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.h
@@ -105,7 +105,6 @@ namespace MultiplayerSample
         friend class NetworkAiComponentController;
 
         void UpdateAI();
-        bool ShouldProcessInput() const;
 
         //! Update pump for player controlled weapons
         //! @param deltaTime the time in seconds since last tick


### PR DESCRIPTION
Stop player movement in between rounds.

Tested by running the player in Starbase and ensuring the player cannot move around in-between rounds, but _can_ move after when a new round or new match begins.