### PR TITLE
Fix aiming desyncs

### DIFF
--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -160,16 +160,6 @@ namespace MultiplayerSample
                 }
                 m_animationGraph->SetParameterFloat(m_movementSpeedParamId, speed);
             }
-
-            // Turn off aiming when character start running.
-            if (speed >= 1.0f)
-            {
-                NetworkAnimationComponentController* controller = static_cast<MultiplayerSample::NetworkAnimationComponentController*>(GetController());
-                if (controller != nullptr)
-                {
-                    controller->ModifyActiveAnimStates().SetBit(aznumeric_cast<uint32_t>(CharacterAnimState::Aiming), false);
-                }
-            }
         }
 
         if (m_aimTargetParamId != InvalidParamIndex)

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -425,6 +425,14 @@ namespace MultiplayerSample
                 aznumeric_cast<uint32_t>(CharacterAnimState::Aiming), true);
         }
 
+        // However, turn off aiming any time the character is sprinting.
+        if (GetNetworkAnimationComponentController()->GetActiveAnimStates().GetBit(aznumeric_cast<uint32_t>(CharacterAnimState::Sprinting)))
+        {
+            GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
+                aznumeric_cast<uint32_t>(CharacterAnimState::Aiming), false);
+        }
+
+
         const AZ::Transform cameraTransform = GetNetworkSimplePlayerCameraComponentController()->GetCameraTransform(/*collisionEnabled=*/false);
 
         for (uint32_t weaponIndexInt = 0; weaponIndexInt < MaxWeaponsPerComponent; ++weaponIndexInt)


### PR DESCRIPTION
There is a class of desyncs (and desync corrections) currently happening because the server is staying in the "aiming" animation state and the client is not.

This PR fixes the desyncs by moving the logic to reset the aiming state into the weapons component ProcessInput() instead of in OnPreRender(). It also switches to using the Sprinting state instead of the character speed to detect Sprinting, so that small velocity errors, or large velocities caused by teleporters / jumppads / etc, don't affect the removal of the aiming state.

I no longer saw these specific desyncs occur after making the change. I still see other occasional weapon firing desyncs, but not the animation state one.