### PR TITLE
Respawn players between rounds

### DIFF
--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -339,7 +339,9 @@ namespace MultiplayerSample
                     continue;
                 }
 
-                RespawnPlayer(playerNetEntity, PlayerResetOptions{ true, 0 });
+                constexpr bool resetShields = true
+                constexpr uint16_t coinPenalty = 0;
+                RespawnPlayer(playerNetEntity, PlayerResetOptions{ resetShields, coinPenalty });
             }
         }
         else // Match ended

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -329,6 +329,18 @@ namespace MultiplayerSample
             // start the rest timer
             ModifyRoundRestTimeRemaining() = RoundTimeSec{ GetRestDurationBetweenRounds() };
             m_restTickEvent.Enqueue(AZ::TimeMs{ 1000 }, true);
+
+            // Respawn players before the new round starts
+            for (const Multiplayer::NetEntityId playerNetEntity : m_players)
+            {
+                const Multiplayer::ConstNetworkEntityHandle playerHandle = Multiplayer::GetNetworkEntityManager()->GetEntity(playerNetEntity);
+                if (!playerHandle.Exists())
+                {
+                    continue;
+                }
+
+                RespawnPlayer(playerNetEntity, PlayerResetOptions{ true, 0 });
+            }
         }
         else // Match ended
         {

--- a/Gem/Code/Source/Components/NetworkMatchComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkMatchComponent.cpp
@@ -339,7 +339,7 @@ namespace MultiplayerSample
                     continue;
                 }
 
-                constexpr bool resetShields = true
+                constexpr bool resetShields = true;
                 constexpr uint16_t coinPenalty = 0;
                 RespawnPlayer(playerNetEntity, PlayerResetOptions{ resetShields, coinPenalty });
             }


### PR DESCRIPTION
Respawn players and restoring shields in-between rounds.

Tested by running Starbase and seeing the players respawn in between rounds