### PR TITLE
Compilation fixes for non-unity builds

### DIFF
--- a/Gem/Code/Source/Components/UI/UiRestBetweenRoundsComponent.h
+++ b/Gem/Code/Source/Components/UI/UiRestBetweenRoundsComponent.h
@@ -8,6 +8,7 @@
 #pragma once
 
 
+#include <MultiplayerSampleTypes.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 


### PR DESCRIPTION
Compiled the project with LY_UNITY_BUILD=OFF