### PR TITLE
Quick Fix for Match End Softlock

### DIFF
--- a/Gem/Code/Source/Components/UI/UiGameOverComponent.cpp
+++ b/Gem/Code/Source/Components/UI/UiGameOverComponent.cpp
@@ -7,11 +7,10 @@
 
 #include <AzCore/Serialization/EditContext.h>
 
-#if AZ_TRAIT_CLIENT
 #include <LyShine/Bus/UiElementBus.h>
 #include <LyShine/Bus/UiCursorBus.h>
 #include <LyShine/Bus/UiTextBus.h>
-#endif
+
 
 #include <Source/Components/UI/UiGameOverComponent.h>
 
@@ -26,7 +25,6 @@ namespace MultiplayerSample
                 ->Field("Game Over root element", &UiGameOverComponent::m_gameOverRootElement)
                 ->Field("Winner Name Text", &UiGameOverComponent::m_winnerNameElement)
                 ->Field("Match Results element", &UiGameOverComponent::m_matchResultsElement)
-                ->Field("Close Results Button", &UiGameOverComponent::m_closeResultsButton)
                 ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -40,8 +38,6 @@ namespace MultiplayerSample
                         "Winner Name Text", "The text element for the name of the match winner")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &UiGameOverComponent::m_matchResultsElement,
                         "Match Results element", "The element for the textual display of the match results")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &UiGameOverComponent::m_closeResultsButton,
-                        "Close Results Button", "The button to close results UI")
                     ;
             }
         }
@@ -49,33 +45,19 @@ namespace MultiplayerSample
 
     void UiGameOverComponent::Activate()
     {
-#if AZ_TRAIT_CLIENT
         UiGameOverBus::Handler::BusConnect(GetEntityId());
-        UiButtonNotificationBus::Handler::BusConnect(m_closeResultsButton);
-#endif
     }
 
     void UiGameOverComponent::Deactivate()
     {
-#if AZ_TRAIT_CLIENT
         UiGameOverBus::Handler::BusDisconnect();
-        UiButtonNotificationBus::Handler::BusDisconnect();
-#endif
+
     }
 
-#if AZ_TRAIT_CLIENT
     void UiGameOverComponent::SetGameOverScreenEnabled(bool enabled)
     {
         UiElementBus::Event(m_gameOverRootElement, &UiElementBus::Events::SetIsEnabled, enabled);
-
-        if (enabled)
-        {
-            UiCursorBus::Broadcast(&UiCursorBus::Events::IncrementVisibleCounter);
-        }
-        else
-        {
-            UiCursorBus::Broadcast(&UiCursorBus::Events::DecrementVisibleCounter);
-        }
+       
     }
 
     void UiGameOverComponent::DisplayResults(MatchResultsSummary results)
@@ -83,15 +65,6 @@ namespace MultiplayerSample
         UiTextBus::Event(m_winnerNameElement, &UiTextBus::Events::SetText, results.m_winningPlayerName.c_str());
         auto resultsSummary = BuildResultsSummary(results.m_playerStates);
         UiTextBus::Event(m_matchResultsElement, &UiTextBus::Events::SetText, resultsSummary);
-    }
-
-    void UiGameOverComponent::OnButtonClick()
-    {
-        const AZ::EntityId buttonId = *UiButtonNotificationBus::GetCurrentBusId();
-        if (buttonId == m_closeResultsButton)
-        {
-            SetGameOverScreenEnabled(false);
-        }
     }
 
     AZStd::string UiGameOverComponent::BuildResultsSummary(const AZStd::vector<PlayerState>& playerStates)
@@ -108,5 +81,4 @@ namespace MultiplayerSample
         }
         return resultTable;
     }
-#endif
 }

--- a/Gem/Code/Source/Components/UI/UiGameOverComponent.h
+++ b/Gem/Code/Source/Components/UI/UiGameOverComponent.h
@@ -10,19 +10,13 @@
 
 #include <AzCore/Component/Component.h>
 
-#if AZ_TRAIT_CLIENT
 #include <UiGameOverBus.h>
-#include <LyShine/Bus/UiButtonBus.h>
-#endif
 
 namespace MultiplayerSample
 {
     class UiGameOverComponent
         : public AZ::Component
-#if AZ_TRAIT_CLIENT
         , public UiGameOverBus::Handler
-        , public UiButtonNotificationBus::Handler
-#endif
     {
     public:
         AZ_COMPONENT(UiGameOverComponent, "{37a2de13-a8fa-4ee1-8652-e17253137f62}");
@@ -32,27 +26,17 @@ namespace MultiplayerSample
         void Activate() override;
         void Deactivate() override;
 
-#if AZ_TRAIT_CLIENT
         //! UiGameOverBus overrides
         //! @{
         void SetGameOverScreenEnabled(bool enabled) override;
         void DisplayResults(MatchResultsSummary results) override;
         //! }@
 
-        //! UiButtonNotificationBus
-        //! @{
-        void OnButtonClick() override;
-        //! }@
-#endif
-
     private:
         AZ::EntityId m_gameOverRootElement;
         AZ::EntityId m_winnerNameElement;
         AZ::EntityId m_matchResultsElement;
-        AZ::EntityId m_closeResultsButton;
 
-#if AZ_TRAIT_CLIENT
         AZStd::string BuildResultsSummary(const AZStd::vector<PlayerState>& playerStates);
-#endif
     };
 }

--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -43,8 +43,8 @@ namespace MultiplayerSample
                 HUDComponent::CreateDescriptor(),
                 NetworkPrefabSpawnerComponent::CreateDescriptor(),
                 UiCoinCountComponent::CreateDescriptor(),
-                UiGameOverComponent::CreateDescriptor(),
                 #if AZ_TRAIT_CLIENT
+                    UiGameOverComponent::CreateDescriptor(),
                     UiPlayerArmorComponent::CreateDescriptor(),
                     UiMatchPlayerCoinCountsComponent::CreateDescriptor(),
                     UiRestBetweenRoundsComponent::CreateDescriptor()

--- a/Gem/Code/multiplayersample_client_files.cmake
+++ b/Gem/Code/multiplayersample_client_files.cmake
@@ -6,10 +6,12 @@
 #
 
 set(FILES
+    Source/Components/UI/UiGameOverComponent.cpp
+    Source/Components/UI/UiGameOverComponent.h
     Source/Components/UI/UiMatchPlayerCoinCountsComponent.cpp
     Source/Components/UI/UiMatchPlayerCoinCountsComponent.h
-    Source/Components/UI/UiRestBetweenRoundsComponent.cpp
-    Source/Components/UI/UiRestBetweenRoundsComponent.h
     Source/Components/UI/UiPlayerArmorComponent.cpp
     Source/Components/UI/UiPlayerArmorComponent.h
+    Source/Components/UI/UiRestBetweenRoundsComponent.cpp
+    Source/Components/UI/UiRestBetweenRoundsComponent.h
 )

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -79,8 +79,6 @@ set(FILES
     Source/Components/UI/HUDComponent.h
     Source/Components/UI/UiCoinCountComponent.cpp
     Source/Components/UI/UiCoinCountComponent.h
-    Source/Components/UI/UiGameOverComponent.cpp
-    Source/Components/UI/UiGameOverComponent.h
     Source/Components/Multiplayer/GameplayEffectsComponent.cpp
     Source/Components/Multiplayer/GameplayEffectsComponent.h
     Source/Components/Multiplayer/GemComponent.cpp


### PR DESCRIPTION
- The match end Ui is a work-in-progress; but this is a quick fix to avoid a soft lock when the match is over.
- Removing the mouse input during game over screen which we don't need and was also causing the game to softlock since there was no way to close the menu.
- Moving UiGameOverComponent to client-only. 