### PR TITLE
Aim for the closest target, not the first target found

### DIFF
--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -532,17 +532,18 @@ namespace MultiplayerSample
 
                         if (AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &physicsRayRequest))
                         {
+                            float minDistance = AZStd::numeric_limits<float>::max();
                             for (const AzPhysics::SceneQueryHit& hit : result.m_hits)
                             {
-                                // Set target to first found intersect within dot tolerance, if any
+                                // Set target to closest found intersection within dot tolerance, if any
                                 AZ::Vector3 targetDirection = hit.m_position - weaponInput->m_shotStartPosition;
                                 AZ::Vector3 aimDirection = physicsRayRequest.m_direction;
                                 targetDirection.Normalize();
                                 aimDirection.Normalize();
-                                if (targetDirection.Dot(aimDirection) > sv_WeaponsDotClamp)
+                                if ((targetDirection.Dot(aimDirection) > sv_WeaponsDotClamp) && (hit.m_distance <= minDistance))
                                 {
                                     aimTarget = hit.m_position;
-                                    break;
+                                    minDistance = hit.m_distance;
                                 }
                             }
                         }


### PR DESCRIPTION
In an attempt to improve close-range shooting at other players, this changes the weapons logic to aim at the closest target that lines up with the reticule, not just the first one found.

The specific problem that I'm trying to fix here is that when two robots are close to each other, sometimes the shots appear to miss because the gun is aimed at a point along the reticule at a much further distance than the robot, causing the shot to go alongside the robot instead of at him. By picking the closest hit point, this should (and seems to) make the other robot the target instead.

I tried to test this by running two clients and it _seemed_ to help, but I can't run multiple clients more than a few seconds on my PC without crashing so I don't have extremely solid validation of this fix. We can back it back out though if it doesn't improve the aiming.