### PR TITLE
Linux: Remove duplicate autogen files to fix build

### DIFF
--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -17,32 +17,6 @@ set(FILES
     Include/UiGameOverBus.h
     Include/UiPlayerArmorBus.h
 
-    Source/AutoGen/EnergyBallComponent.AutoComponent.xml
-    Source/AutoGen/EnergyCannonComponent.AutoComponent.xml
-    Source/AutoGen/GameplayEffectsComponent.AutoComponent.xml
-    Source/AutoGen/GemComponent.AutoComponent.xml
-    Source/AutoGen/GemSpawnerComponent.AutoComponent.xml
-    Source/AutoGen/MatchPlayerCoinsComponent.AutoComponent.xml
-    Source/AutoGen/NetworkAiComponent.AutoComponent.xml
-    Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml
-    Source/AutoGen/NetworkHealthComponent.AutoComponent.xml
-    Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
-    Source/AutoGen/NetworkPlayerMovementComponent.AutoComponent.xml
-    Source/AutoGen/NetworkRandomComponent.AutoComponent.xml
-    Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
-    Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
-    Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml
-    Source/AutoGen/NetworkStressTestComponent.AutoComponent.xml
-    Source/AutoGen/NetworkTeleportCompatibleComponent.AutoComponent.xml
-    Source/AutoGen/NetworkTeleportComponent.AutoComponent.xml
-    Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
-    Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
-    Source/AutoGen/PlayerArmorComponent.AutoComponent.xml
-    Source/AutoGen/PlayerCoinCollectorComponent.AutoComponent.xml
-    Source/AutoGen/PlayerIdentityComponent.AutoComponent.xml
-    Source/AutoGen/PlayerKnockbackEffectComponent.AutoComponent.xml
-    Source/AutoGen/RpcTesterComponent.AutoComponent.xml
-
     Source/Components/ExampleFilteredEntityComponent.h
     Source/Components/ExampleFilteredEntityComponent.cpp
     Source/Components/NetworkAiComponent.cpp


### PR DESCRIPTION
Autogen files are included here: https://github.com/aws-lumberyard-dev/o3de-multiplayersample/blob/GameJam_2022_07/Gem/Code/multiplayersample_autogen_files.cmake

Double include breaks ninja config on Linux

## Prior to fix
Project configuration ie  `cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=/root/.o3de/3rdParty/` fails with:

```
ninja: error: CMakeFiles/impl-profile.ninja:35814: multiple rules generate External/Gem-f6f5d0f3/Code/Azcg/Generated/MultiplayerSample.Client.Static/Source/AutoGen/EnergyBallComponent.AutoComponent.h [-w dupbuild=err]
```

## After fix
Can build Editor on Ubuntu.